### PR TITLE
fix: x1 base-lidar launcher

### DIFF
--- a/sensor/extrinsic_calibration_manager/launch/aip_x1/ground_plane_sensor_kit.launch.xml
+++ b/sensor/extrinsic_calibration_manager/launch/aip_x1/ground_plane_sensor_kit.launch.xml
@@ -22,9 +22,7 @@
   <node pkg="extrinsic_calibration_manager" exec="extrinsic_calibration_manager" name="extrinsic_calibration_manager" output="screen">
     <param name="parent_frame" value="$(var parent_frame)" />
     <param name="child_frames" value="
-    [velodyne_top_base_link,
-    livox_front_center_base_link,
-    livox_front_right_base_link]" />
+    [velodyne_top_base_link]" />
   </node>
 
   <!-- velodyne_top_base_link: extrinsic_ground_plane_calibrator -->
@@ -39,23 +37,5 @@
   </group>
 
   <node pkg="rviz2" exec="rviz2" name="rviz2" output="screen" args="-d $(var rviz_profile)" if="$(var rviz)"/>
-
-  <!-- livox_front_center_base_link: extrinsic_dummy_calibrator -->
-  <group>
-    <include file="$(find-pkg-share extrinsic_dummy_calibrator)/launch/calibrator.launch.xml">
-      <arg name="ns" value="$(var parent_frame)/livox_front_center_base_link" />
-      <arg name="parent_frame" value="$(var parent_frame)" />
-      <arg name="child_frame" value="livox_front_center_base_link" />
-    </include>
-  </group>
-
-  <!-- livox_front_right_base_link: extrinsic_dummy_calibrator -->
-  <group>
-    <include file="$(find-pkg-share extrinsic_dummy_calibrator)/launch/calibrator.launch.xml">
-      <arg name="ns" value="$(var parent_frame)/livox_front_right_base_link" />
-      <arg name="parent_frame" value="$(var parent_frame)" />
-      <arg name="child_frame" value="livox_front_right_base_link" />
-    </include>
-  </group>
 
 </launch>


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
It was decided that non-calibrated tfs would not be included in the output yaml file, but since the base-lidar calibration was not yet available at that time, it was not updated.

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/