### PR TITLE
fix(readme): refer to own repos file

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,28 +25,28 @@ colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
 
 We provide calibration tool for sensor pairs like LiDAR - LiDAR, LiDAR - Camera, etc.
 
-[README](https://github.com/tier4/calibration_tools.iv/blob/tier4/universe/sensor/README.md)
+[README](sensor/README.md)
 
 ### localization - deviation estimation tools
 
 Estimate parameters of sensors used for dead reckoning (IMU and odometry) for a better localization performance
 
-[README](https://github.com/tier4/calibration_tools.iv/blob/tier4/universe/localization/deviation_estimation_tools/ReadMe.md)
+[README](localization/deviation_estimation_tools/ReadMe.md)
 
 ### control - vehicle cmd analyzer
 
 Visualization and analysis tools for the control outputs from Autoware
 
-[README](https://github.com/tier4/calibration_tools.iv/blob/tier4/universe/control/vehicle_cmd_analyzer/README.md)
+[README](control/vehicle_cmd_analyzer/README.md)
 
 ### vehicle - time delay estimator
 
 Calibration tool to fix the delay of the commands to the vehicle
 
-[README](https://github.com/tier4/calibration_tools.iv/blob/tier4/universe/vehicle/time_delay_estimator/README.md)
+[README](vehicle/time_delay_estimator/README.md)
 
 ### system - tunable static tf broadcaster
 
 GUI to modify the parameters of generic TFs.
 
-[README](https://github.com/tier4/calibration_tools.iv/blob/tier4/universe/system/tunable_static_tf_broadcaster/README.md)
+[README](system/tunable_static_tf_broadcaster/README.md)

--- a/README.md
+++ b/README.md
@@ -4,21 +4,18 @@ Calibration tools used for autonomous driving
 
 ## Requirement
 
-- Ubuntu20.04
-- Ros Galactic
-
+- Ubuntu 20.04
+- ROS 2 Galactic
 
 ## Installation procedures
 
-After cloning pilot-auto(private repository) or [autoware](https://github.com/tier4/autoware), execute the following commands:
+After installing [autoware](https://github.com/tier4/autoware) (please see [source-installation](https://autowarefoundation.github.io/autoware-documentation/main/installation/autoware/source-installation/) page), execute the following commands:
 
 ```bash
-mkdir src
-vcs import src < autoware.repos
-cd src/autoware
-git clone git@github.com:tier4/CalibrationTools.git
-cd ../../
-vcs import src < src/autoware/calibration_tools/calibration_tools.repos
+cd autoware
+wget https://raw.githubusercontent.com/tier4/CalibrationTools/tier4/universe/calibration_tools.repos
+vcs import src < calibration_tools.repos
+rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO
 colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
 ```
 

--- a/calibration_tools.repos
+++ b/calibration_tools.repos
@@ -1,7 +1,7 @@
 repositories:
   autoware/calibration_tools:
     type: git
-    url: git@github.com:tier4/calibration_tools.git
+    url: git@github.com:tier4/CalibrationTools.git
     version: tier4/universe
   vendor/lidartag:
     type: git

--- a/calibration_tools.repos
+++ b/calibration_tools.repos
@@ -1,4 +1,8 @@
 repositories:
+  autoware/calibration_tools:
+    type: git
+    url: git@github.com:tier4/calibration_tools.git
+    version: tier4/universe
   vendor/lidartag:
     type: git
     url: git@github.com:tier4/LiDARTag.git
@@ -19,3 +23,7 @@ repositories:
     type: git
     url: git@github.com:Box-Robotics/ros2_numpy.git
     version: rolling
+  vendor/image_pipeline:
+    type: git
+    url: https://github.com/tier4/image_pipeline.git
+    version: 47964112293eb19f9f57254b2e6b68706954cc63

--- a/sensor/README.md
+++ b/sensor/README.md
@@ -1,16 +1,5 @@
 # Sensor Calibration Tools
 
-## Calibration tools installation (alongside autoware)
-
-After cloning autoware, execute the following commands:
-
-```sh
-mkdir src
-vcs import src < autoware.proj.repos
-vcs import src < src/autoware/calibration_tools/calibration_tools.repos
-colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
-```
-
 ## Extrinsic Calibration
 
 - [How to Extrinsic Manual Calibration](docs/how_to_extrinsic_manual.md)


### PR DESCRIPTION
## Description

I changed to manage repos file in`calibration_tools` to build itself in parallel with autoware setup.

## Related links

<!-- Write the links related to this PR. -->

Please refer to [Installation procedures](https://github.com/tier4/CalibrationTools/tree/fix/readme_repos#installation-procedures) in this PR.
(NOTE: Change `tier4/universe` -> `fix/readme_repos` in this review process.)

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/