### PR TITLE
feat: change ros2_numpy branch in repos to humble

### DIFF
--- a/calibration_tools.repos
+++ b/calibration_tools.repos
@@ -18,4 +18,4 @@ repositories:
   vendor/ros2_numpy:
     type: git
     url: git@github.com:Box-Robotics/ros2_numpy.git
-    version: rolling
+    version: humble


### PR DESCRIPTION
## Description

It is nessesary this change for humble.
https://github.com/Box-Robotics/ros2_numpy/commit/9bb21a13eaa2f8084cef797539629ab8d806c44b

So I fix ros2_numpy branch to humble.

<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

- vcs import at humble.
- rosdep install and build
  - rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO
  - colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/