### PR TITLE
fix(extrinsic_tag_based_calibrator): change in image topic used by apriltag

### DIFF
--- a/sensor/extrinsic_tag_based_calibrator/launch/apriltag_16h5.launch.py
+++ b/sensor/extrinsic_tag_based_calibrator/launch/apriltag_16h5.launch.py
@@ -29,6 +29,7 @@ def generate_launch_description():
         package='apriltag_ros', plugin='AprilTagNode',
         remappings=[
             ("image", LaunchConfiguration("image_topic")),
+            ("image_rect", LaunchConfiguration("image_topic")),
             ("camera_info", LaunchConfiguration("camera_info_topic")),
             ("detections", LaunchConfiguration("apriltag_detections_topic"))],
         parameters=[cfg_16h5])


### PR DESCRIPTION
## Description

Apriltag changed the name of the topic is the image causing our calibrator to fail.
The change in our launcher makes it compatible with the new and old topic names
<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
