### PR TITLE
fix:(extrinsic_tag_based_calibrator): Fixed the apriltag version

### DIFF
--- a/calibration_tools.repos
+++ b/calibration_tools.repos
@@ -18,7 +18,7 @@ repositories:
   vendor/apriltag_ros:
     type: git
     url: git@github.com:christianrauch/apriltag_ros.git
-    version: master
+    version: 0f5ee01e01a0e8074c186ddcdd1f85a36d0cb5d5
   vendor/ros2_numpy:
     type: git
     url: git@github.com:Box-Robotics/ros2_numpy.git

--- a/calibration_tools.repos
+++ b/calibration_tools.repos
@@ -14,7 +14,7 @@ repositories:
   vendor/apriltag_msgs:
     type: git
     url: git@github.com:christianrauch/apriltag_msgs.git
-    version: master
+    version: 2.0.0
   vendor/apriltag_ros:
     type: git
     url: git@github.com:christianrauch/apriltag_ros.git


### PR DESCRIPTION
## Description
Fixed the apriltag_version since the API is unstable right now, and the newest commit required an unavailable library in galactic
We can move to the latest branch/tag when we migrate to humble


<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
