### PR TITLE
fix(extrinsic_interactive_calibrator): fixed a typo and conformed to standards

### DIFF
--- a/sensor/extrinsic_interactive_calibrator/extrinsic_interactive_calibrator/calibrator.py
+++ b/sensor/extrinsic_interactive_calibrator/extrinsic_interactive_calibrator/calibrator.py
@@ -53,7 +53,7 @@ class Calibrator:
         if method == "sqpnp":
             self.flags = cv2.SOLVEPNP_SQPNP
         else:
-            self.flags = None
+            self.flags = cv2.SOLVEPNP_ITERATIVE
 
     def set_ransac(self, use_ransac):
         self.use_ransac = use_ransac
@@ -84,7 +84,7 @@ class Calibrator:
                 object_points, image_points, self.k, self.d, flags=self.flags
             )
         except Exception as e:
-            pass
+            print(e)
 
         camera_to_lidar_transform = cv_to_transformation_matrix(tvec, rvec)
 
@@ -92,14 +92,14 @@ class Calibrator:
 
     def calibrate_ransac(self, object_points, image_points):
 
-        num_points, dim = object_points.shape
+        num_points, _ = object_points.shape
 
         best_tvec = np.zeros((3,))
         best_rvec = np.zeros((3, 3))
         best_inliers = -1
         best_error = np.inf
 
-        for iter in range(self.ransac_iters):
+        for _ in range(self.ransac_iters):
 
             indexes = np.random.choice(num_points, min(num_points, self.min_points))
             object_points_iter = object_points[indexes, :]
@@ -110,6 +110,7 @@ class Calibrator:
                     object_points_iter, image_points_iter, self.k, self.d, flags=self.flags
                 )
             except Exception as e:
+                print(e)
                 continue
 
             reproj_error_iter, inliers = self.calculate_reproj_error(


### PR DESCRIPTION
Signed-off-by: Kenzo Lobos-Tsunekawa <kenzo.lobos@tier4.jp>

## Description
There was a typo that caused the iterative PNP method to fail.

<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
