### PR TITLE
fix(extrinsic_tag_calibrator): deleted subscription to the original raw images

### DIFF
--- a/sensor/extrinsic_calibration_manager/launch/aip_x2/tag_based.launch.xml
+++ b/sensor/extrinsic_calibration_manager/launch/aip_x2/tag_based.launch.xml
@@ -4,7 +4,6 @@
   <let name="sensor_model" value="aip_x2"/>
   <arg name="camera_name" default=""/>
   <arg name="rviz" default="false"/>
-  <arg name="decompress_images" default="true"/>
 
   <group>
     <push-ros-namespace namespace="front_unit"/>
@@ -31,68 +30,5 @@
       <arg name="camera_name" value="$(var camera_name)"/>
       <arg name="rviz" value="$(var rviz)"/>
     </include>
-  </group>
-
-  <group if="$(var decompress_images)">
-    <push-ros-namespace namespace="sensing/camera/camera0"/>
-
-    <node pkg="image_transport_decompressor" exec="image_transport_decompressor_node" name="decompressor" output="screen">
-      <remap from="decompressor/input/compressed_image" to="image_raw/compressed"/>
-      <remap from="decompressor/output/raw_image" to="image_raw"/>
-    </node>
-  </group>
-
-  <group if="$(var decompress_images)">
-    <push-ros-namespace namespace="sensing/camera/camera1"/>
-
-    <node pkg="image_transport_decompressor" exec="image_transport_decompressor_node" name="decompressor" output="screen">
-      <remap from="decompressor/input/compressed_image" to="image_raw/compressed"/>
-      <remap from="decompressor/output/raw_image" to="image_raw"/>
-    </node>
-  </group>
-
-  <group if="$(var decompress_images)">
-    <push-ros-namespace namespace="sensing/camera/camera2"/>
-
-    <node pkg="image_transport_decompressor" exec="image_transport_decompressor_node" name="decompressor" output="screen">
-      <remap from="decompressor/input/compressed_image" to="image_raw/compressed"/>
-      <remap from="decompressor/output/raw_image" to="image_raw"/>
-    </node>
-  </group>
-
-  <group if="$(var decompress_images)">
-    <push-ros-namespace namespace="sensing/camera/camera3"/>
-
-    <node pkg="image_transport_decompressor" exec="image_transport_decompressor_node" name="decompressor" output="screen">
-      <remap from="decompressor/input/compressed_image" to="image_raw/compressed"/>
-      <remap from="decompressor/output/raw_image" to="image_raw"/>
-    </node>
-  </group>
-
-  <group if="$(var decompress_images)">
-    <push-ros-namespace namespace="sensing/camera/camera4"/>
-
-    <node pkg="image_transport_decompressor" exec="image_transport_decompressor_node" name="decompressor" output="screen">
-      <remap from="decompressor/input/compressed_image" to="image_raw/compressed"/>
-      <remap from="decompressor/output/raw_image" to="image_raw"/>
-    </node>
-  </group>
-
-  <group if="$(var decompress_images)">
-    <push-ros-namespace namespace="sensing/camera/camera5"/>
-
-    <node pkg="image_transport_decompressor" exec="image_transport_decompressor_node" name="decompressor" output="screen">
-      <remap from="decompressor/input/compressed_image" to="image_raw/compressed"/>
-      <remap from="decompressor/output/raw_image" to="image_raw"/>
-    </node>
-  </group>
-
-  <group if="$(var decompress_images)">
-    <push-ros-namespace namespace="sensing/camera/camera6"/>
-
-    <node pkg="image_transport_decompressor" exec="image_transport_decompressor_node" name="decompressor" output="screen">
-      <remap from="decompressor/input/compressed_image" to="image_raw/compressed"/>
-      <remap from="decompressor/output/raw_image" to="image_raw"/>
-    </node>
   </group>
 </launch>

--- a/sensor/extrinsic_calibration_manager/launch/aip_x2/tag_based_front_unit.launch.xml
+++ b/sensor/extrinsic_calibration_manager/launch/aip_x2/tag_based_front_unit.launch.xml
@@ -28,12 +28,20 @@
       [$(var camera_frame)]"/>
   </node>
 
+  <!-- image decompressor -->
+  <group if="$(var calibrate_sensor)">
+    <node pkg="image_transport_decompressor" exec="image_transport_decompressor_node" name="decompressor" output="screen">
+      <remap from="decompressor/input/compressed_image" to="/sensing/camera/$(var camera_name)/image_raw/compressed"/>
+      <remap from="decompressor/output/raw_image" to="/sensing/camera/$(var camera_name)/image_raw/decompressed"/>
+    </node>
+  </group>
+
   <!-- tag based calibrator -->
   <include file="$(find-pkg-share extrinsic_tag_based_calibrator)/launch/calibrator.launch.xml" if="$(var calibrate_sensor)">
     <arg name="ns" value="$(var parent_frame)/$(var camera_frame)"/>
     <arg name="parent_frame" value="$(var parent_frame)"/>
     <arg name="child_frame" value="$(var camera_frame)"/>
-    <arg name="image_topic" value="/sensing/camera/$(var camera_name)/image_raw"/>
+    <arg name="image_topic" value="/sensing/camera/$(var camera_name)/image_raw/decompressed"/>
     <arg name="camera_info_topic" value="/sensing/camera/$(var camera_name)/camera_info"/>
     <arg name="pointcloud_topic" value="/sensing/lidar/front_lower/pointcloud_raw"/>
     <arg name="lidar_model" value="$(var lidar_model)"/>

--- a/sensor/extrinsic_calibration_manager/launch/aip_x2/tag_based_rear_unit.launch.xml
+++ b/sensor/extrinsic_calibration_manager/launch/aip_x2/tag_based_rear_unit.launch.xml
@@ -28,12 +28,20 @@
     [$(var camera_frame)]"/>
   </node>
 
+  <!-- image decompressor -->
+  <group if="$(var calibrate_sensor)">
+    <node pkg="image_transport_decompressor" exec="image_transport_decompressor_node" name="decompressor" output="screen">
+      <remap from="decompressor/input/compressed_image" to="/sensing/camera/$(var camera_name)/image_raw/compressed"/>
+      <remap from="decompressor/output/raw_image" to="/sensing/camera/$(var camera_name)/image_raw/decompressed"/>
+    </node>
+  </group>
+
   <!-- tag based calibrator -->
   <include file="$(find-pkg-share extrinsic_tag_based_calibrator)/launch/calibrator.launch.xml" if="$(var calibrate_sensor)">
     <arg name="ns" value="$(var parent_frame)/$(var camera_frame)"/>
     <arg name="parent_frame" value="$(var parent_frame)"/>
     <arg name="child_frame" value="$(var camera_frame)"/>
-    <arg name="image_topic" value="/sensing/camera/$(var camera_name)/image_raw"/>
+    <arg name="image_topic" value="/sensing/camera/$(var camera_name)/image_raw/decompressed"/>
     <arg name="camera_info_topic" value="/sensing/camera/$(var camera_name)/camera_info"/>
     <arg name="pointcloud_topic" value="/sensing/lidar/rear_lower/pointcloud_raw"/>
     <arg name="lidar_model" value="$(var lidar_model)"/>

--- a/sensor/extrinsic_calibration_manager/launch/aip_x2/tag_based_top_unit.launch.xml
+++ b/sensor/extrinsic_calibration_manager/launch/aip_x2/tag_based_top_unit.launch.xml
@@ -6,7 +6,7 @@
   <arg name="camera_name"/>
   <arg name="rviz"/>
 
-  <let name="image_topic" value="/sensing/camera/$(var camera_name)/image_raw"/>
+  <let name="image_decompressed_topic" value="/sensing/camera/$(var camera_name)/image_raw/decompressed"/>
   <let name="image_compressed_topic" value="/sensing/camera/$(var camera_name)/image_raw/compressed"/>
   <let name="camera_info_topic" value="/sensing/camera/$(var camera_name)/camera_info"/>
 
@@ -46,12 +46,20 @@
     [$(var camera_frame)]"/>
   </node>
 
+  <!-- image decompressor -->
+  <group if="$(var calibrate_sensor)">
+    <node pkg="image_transport_decompressor" exec="image_transport_decompressor_node" name="decompressor" output="screen">
+      <remap from="decompressor/input/compressed_image" to="$(var image_compressed_topic)"/>
+      <remap from="decompressor/output/raw_image" to="$(var image_decompressed_topic)"/>
+    </node>
+  </group>
+
   <!-- tag based calibrator -->
   <include file="$(find-pkg-share extrinsic_tag_based_calibrator)/launch/calibrator.launch.xml" if="$(var calibrate_sensor)">
     <arg name="ns" value="$(var parent_frame)/$(var camera_name)/camera_link"/>
     <arg name="parent_frame" value="$(var parent_frame)"/>
     <arg name="child_frame" value="$(var camera_frame)"/>
-    <arg name="image_topic" value="$(var image_topic)"/>
+    <arg name="image_topic" value="$(var image_decompressed_topic)"/>
     <arg name="camera_info_topic" value="$(var camera_info_topic)"/>
     <arg name="pointcloud_topic" value="$(var pointcloud_topic)"/>
     <arg name="lidar_model" value="$(var lidar_model)"/>

--- a/sensor/extrinsic_calibration_manager/launch/aip_xx1/tag_based.launch.xml
+++ b/sensor/extrinsic_calibration_manager/launch/aip_xx1/tag_based.launch.xml
@@ -4,7 +4,6 @@
   <let name="sensor_model" value="aip_xx1"/>
   <arg name="camera_name" default=""/>
   <arg name="rviz" default="false"/>
-  <arg name="decompress_images" default="true"/>
 
   <group>
     <push-ros-namespace namespace="sensor_kit"/>
@@ -13,68 +12,5 @@
       <arg name="camera_name" value="$(var camera_name)"/>
       <arg name="rviz" value="$(var rviz)"/>
     </include>
-  </group>
-
-  <group if="$(var decompress_images)">
-    <push-ros-namespace namespace="sensing/camera/camera0"/>
-
-    <node pkg="image_transport_decompressor" exec="image_transport_decompressor_node" name="decompressor" output="screen">
-      <remap from="decompressor/input/compressed_image" to="image_raw/compressed"/>
-      <remap from="decompressor/output/raw_image" to="image_raw"/>
-    </node>
-  </group>
-
-  <group if="$(var decompress_images)">
-    <push-ros-namespace namespace="sensing/camera/camera1"/>
-
-    <node pkg="image_transport_decompressor" exec="image_transport_decompressor_node" name="decompressor" output="screen">
-      <remap from="decompressor/input/compressed_image" to="image_raw/compressed"/>
-      <remap from="decompressor/output/raw_image" to="image_raw"/>
-    </node>
-  </group>
-
-  <group if="$(var decompress_images)">
-    <push-ros-namespace namespace="sensing/camera/camera2"/>
-
-    <node pkg="image_transport_decompressor" exec="image_transport_decompressor_node" name="decompressor" output="screen">
-      <remap from="decompressor/input/compressed_image" to="image_raw/compressed"/>
-      <remap from="decompressor/output/raw_image" to="image_raw"/>
-    </node>
-  </group>
-
-  <group if="$(var decompress_images)">
-    <push-ros-namespace namespace="sensing/camera/camera3"/>
-
-    <node pkg="image_transport_decompressor" exec="image_transport_decompressor_node" name="decompressor" output="screen">
-      <remap from="decompressor/input/compressed_image" to="image_raw/compressed"/>
-      <remap from="decompressor/output/raw_image" to="image_raw"/>
-    </node>
-  </group>
-
-  <group if="$(var decompress_images)">
-    <push-ros-namespace namespace="sensing/camera/camera4"/>
-
-    <node pkg="image_transport_decompressor" exec="image_transport_decompressor_node" name="decompressor" output="screen">
-      <remap from="decompressor/input/compressed_image" to="image_raw/compressed"/>
-      <remap from="decompressor/output/raw_image" to="image_raw"/>
-    </node>
-  </group>
-
-  <group if="$(var decompress_images)">
-    <push-ros-namespace namespace="sensing/camera/camera5"/>
-
-    <node pkg="image_transport_decompressor" exec="image_transport_decompressor_node" name="decompressor" output="screen">
-      <remap from="decompressor/input/compressed_image" to="image_raw/compressed"/>
-      <remap from="decompressor/output/raw_image" to="image_raw"/>
-    </node>
-  </group>
-
-  <group if="$(var decompress_images)">
-    <push-ros-namespace namespace="sensing/camera/traffic_light"/>
-
-    <node pkg="image_transport_decompressor" exec="image_transport_decompressor_node" name="decompressor" output="screen">
-      <remap from="decompressor/input/compressed_image" to="image_raw/compressed"/>
-      <remap from="decompressor/output/raw_image" to="image_raw"/>
-    </node>
   </group>
 </launch>

--- a/sensor/extrinsic_calibration_manager/launch/aip_xx1/tag_based_sensor_kit.launch.xml
+++ b/sensor/extrinsic_calibration_manager/launch/aip_xx1/tag_based_sensor_kit.launch.xml
@@ -7,8 +7,9 @@
   <arg name="camera_name"/>
   <arg name="rviz"/>
 
-  <let name="image_topic" value="/sensing/camera/$(var camera_name)/image_raw"/>
-  <let name="image_topic" value="/sensing/camera/traffic_light/image_raw" if="$(eval &quot;'$(var camera_name)' == 'traffic_light_left_camera' &quot;)"/>
+  <!-- we do not use the standard image_raw name to avoid naming conflicts -->
+  <let name="image_decompressed_topic" value="/sensing/camera/$(var camera_name)/image_raw/decompressed"/>
+  <let name="image_decompressed_topic" value="/sensing/camera/traffic_light/image_raw/decompressed" if="$(eval &quot;'$(var camera_name)' == 'traffic_light_left_camera' &quot;)"/>
 
   <let name="image_compressed_topic" value="/sensing/camera/$(var camera_name)/image_raw/compressed"/>
   <let name="image_compressed_topic" value="/sensing/camera/traffic_light/image_raw/compressed" if="$(eval &quot;'$(var camera_name)' == 'traffic_light_left_camera' &quot;)"/>
@@ -72,12 +73,18 @@
     [$(var camera_frame)]"/>
   </node>
 
+  <!-- image decompressor -->
+  <node pkg="image_transport_decompressor" exec="image_transport_decompressor_node" name="decompressor" output="screen">
+    <remap from="decompressor/input/compressed_image" to="$(var image_compressed_topic)"/>
+    <remap from="decompressor/output/raw_image" to="$(var image_decompressed_topic)"/>
+  </node>
+
   <!-- tag based calibrator -->
   <include file="$(find-pkg-share extrinsic_tag_based_calibrator)/launch/calibrator.launch.xml" if="$(var calibrate_sensor)">
     <arg name="ns" value="$(var parent_frame)/$(var camera_name)/camera_link"/>
     <arg name="parent_frame" value="$(var parent_frame)"/>
     <arg name="child_frame" value="$(var camera_frame)"/>
-    <arg name="image_topic" value="$(var image_topic)"/>
+    <arg name="image_topic" value="$(var image_decompressed_topic)"/>
     <arg name="camera_info_topic" value="$(var camera_info_topic)"/>
     <arg name="pointcloud_topic" value="$(var pointcloud_topic)"/>
     <arg name="pointcloud_topic_ex" value="$(var camera_info_topic)"/>

--- a/sensor/extrinsic_calibration_manager/launch/calibration.launch.xml
+++ b/sensor/extrinsic_calibration_manager/launch/calibration.launch.xml
@@ -15,7 +15,6 @@
   <arg name="camera_name" default=""/>
   <!--e.g, camera6-->
   <arg name="calibration_rviz" default="true"/>
-  <arg name="decompress_images" default="true"/>
 
   <!-- interactive only -->
   <arg name="interactive_use_concatenated" default="true"/>
@@ -75,7 +74,6 @@
         <arg name="vehicle_id" value="$(var vehicle_id)"/>
         <arg name="camera_name" value="$(var camera_name)"/>
         <arg name="rviz" value="$(var calibration_rviz)"/>
-        <arg name="decompress_images" value="$(var decompress_images)"/>
       </include>
     </group>
 


### PR DESCRIPTION

## Description
As discussed before, subscribing to the original raw images generated a non-acceptable burden on the bandwidth of the camera ECU so we instead subscribe only to the compressed images and decompress them locally to an aux topic (with a different name)
<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. -->

## Tests performed
Run all the cameras for the X2 and XX1 and checked that the wiring of the topics was correct

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
