### PR TITLE
fix: use twist_with_covariance_raw for input

### DIFF
--- a/localization/deviation_estimation_tools/ReadMe.md
+++ b/localization/deviation_estimation_tools/ReadMe.md
@@ -143,10 +143,10 @@ The parameters and input topic names can be seen in the `deviation_estimator.lau
 
 #### Input
 
-| Name                                                  | Type                                             | Description           |
-| ----------------------------------------------------- | ------------------------------------------------ | --------------------- |
-| `/localization/pose_estimator/pose_with_covariance`   | `geometry_msgs::msg::PoseWithCovarianceStamped`  | Input pose (default)  |
-| `/localization/pose_estimator/pose`                   | `geometry_msgs::msg::PoseStamped`                | Input pose            |
+| Name                                                      | Type                                             | Description           |
+| --------------------------------------------------------- | ------------------------------------------------ | --------------------- |
+| `/localization/pose_estimator/pose_with_covariance`       | `geometry_msgs::msg::PoseWithCovarianceStamped`  | Input pose (default)  |
+| `/localization/pose_estimator/pose`                       | `geometry_msgs::msg::PoseStamped`                | Input pose            |
 | `/localization/twist_estimator/twist_with_covariance_raw` | `geometry_msgs::msg::TwistWithCovarianceStamped` | Input twist (default) |
 | `/localization/twist_estimator/twist_raw`                 | `geometry_msgs::msg::TwistStamped`               | Input twist           |
 
@@ -253,10 +253,10 @@ The architecture of `deviation_evaluator` is shown below. It launches two `ekf_l
 
 #### Input
 
-| Name                                                  | Type                                             | Description |
-| ----------------------------------------------------- | ------------------------------------------------ | ----------- |
+| Name                                                      | Type                                             | Description |
+| --------------------------------------------------------- | ------------------------------------------------ | ----------- |
 | `/localization/twist_estimator/twist_with_covariance_raw` | `geometry_msgs::msg::TwistWithCovarianceStamped` | Input twist |
-| `/localization/pose_estimator/pose_with_covariance`   | `geometry_msgs::msg::PoseWithCovarianceStamped`  | Input pose  |
+| `/localization/pose_estimator/pose_with_covariance`       | `geometry_msgs::msg::PoseWithCovarianceStamped`  | Input pose  |
 
 #### Output
 

--- a/localization/deviation_estimation_tools/ReadMe.md
+++ b/localization/deviation_estimation_tools/ReadMe.md
@@ -30,7 +30,6 @@ If you are using rosbag, it should contain the following topics:
 - /localization/pose_estimator/pose_with_covariance
 - /clock
 - /tf_static (that contains transform from `base_link` to `imu_link`)
-- (/localization/twist_estimator/twist_with_covariance: required in the next step)
 
 NOTE that the pose and twist must be estimated with default parameters (see `known issues` section for detail).
 
@@ -148,8 +147,8 @@ The parameters and input topic names can be seen in the `deviation_estimator.lau
 | ----------------------------------------------------- | ------------------------------------------------ | --------------------- |
 | `/localization/pose_estimator/pose_with_covariance`   | `geometry_msgs::msg::PoseWithCovarianceStamped`  | Input pose (default)  |
 | `/localization/pose_estimator/pose`                   | `geometry_msgs::msg::PoseStamped`                | Input pose            |
-| `/localization/twist_estimator/twist_with_covariance` | `geometry_msgs::msg::TwistWithCovarianceStamped` | Input twist (default) |
-| `/localization/twist_estimator/twist`                 | `geometry_msgs::msg::TwistStamped`               | Input twist           |
+| `/localization/twist_estimator/twist_with_covariance_raw` | `geometry_msgs::msg::TwistWithCovarianceStamped` | Input twist (default) |
+| `/localization/twist_estimator/twist_raw`                 | `geometry_msgs::msg::TwistStamped`               | Input twist           |
 
 #### Output
 
@@ -256,7 +255,7 @@ The architecture of `deviation_evaluator` is shown below. It launches two `ekf_l
 
 | Name                                                  | Type                                             | Description |
 | ----------------------------------------------------- | ------------------------------------------------ | ----------- |
-| `/localization/twist_estimator/twist_with_covariance` | `geometry_msgs::msg::TwistWithCovarianceStamped` | Input twist |
+| `/localization/twist_estimator/twist_with_covariance_raw` | `geometry_msgs::msg::TwistWithCovarianceStamped` | Input twist |
 | `/localization/pose_estimator/pose_with_covariance`   | `geometry_msgs::msg::PoseWithCovarianceStamped`  | Input pose  |
 
 #### Output

--- a/localization/deviation_estimation_tools/deviation_evaluator/config/deviation_evaluator.param.yaml
+++ b/localization/deviation_estimation_tools/deviation_evaluator/config/deviation_evaluator.param.yaml
@@ -1,13 +1,15 @@
 /**:
   ros__parameters:
     # Parameters that you want to evaluate
-    # Results expressed in base_link
-    # Copy the following to deviation_evaluator.param.yaml
-    stddev_vx: 0.25309
-    stddev_wz: 0.00191
-    coef_vx: 1.01624
-    bias_wz: -0.00631
+    stddev_vx: 0.3
+    stddev_wz: 0.02
+    coef_vx: 1.0
+    bias_wz: 0.0
 
     # Dead Reckoning configuration
     period: 10.0 # [s]
     cut: 9.0 # [s]
+
+    # Stop mask threshold (this should be manually synced with gyro_odometer in Autoware Universe)
+    vx_threshold: 0.01 # [m/s]
+    wz_threshold: 0.01 # [m/s]

--- a/localization/deviation_estimation_tools/deviation_evaluator/include/deviation_evaluator/deviation_evaluator.hpp
+++ b/localization/deviation_estimation_tools/deviation_evaluator/include/deviation_evaluator/deviation_evaluator.hpp
@@ -71,6 +71,8 @@ private:
   double bias_wz_;
   double period_;
   double cut_;
+  double vx_threshold_;
+  double wz_threshold_;
 
   geometry_msgs::msg::PoseStamped::SharedPtr current_ekf_gt_pose_ptr_;
   geometry_msgs::msg::PoseStamped::SharedPtr current_ndt_pose_ptr_;

--- a/localization/deviation_estimation_tools/deviation_evaluator/launch/deviation_evaluator.launch.xml
+++ b/localization/deviation_estimation_tools/deviation_evaluator/launch/deviation_evaluator.launch.xml
@@ -7,7 +7,7 @@
   <arg name="save_dir" default="$(env HOME)/deviation_evaluator_sample"/>
   <arg name="param_path" default="$(find-pkg-share deviation_evaluator)/config/deviation_evaluator.param.yaml"/>
 
-  <arg name="in_twist_with_covariance" default="/localization/twist_estimator/twist_with_covariance"/>
+  <arg name="in_twist_with_covariance" default="/localization/twist_estimator/twist_with_covariance_raw"/>
   <arg name="in_ndt_pose_with_covariance" default="/localization/pose_estimator/pose_with_covariance"/>
   <arg name="out_ekf_odom_dr" default="/deviation_evaluator/dead_reckoning/ekf_localizer/kinematic_state"/>
   <arg name="out_ekf_odom_gt" default="/deviation_evaluator/ground_truth/ekf_localizer/kinematic_state"/>

--- a/localization/deviation_estimation_tools/deviation_evaluator/src/deviation_evaluator.cpp
+++ b/localization/deviation_estimation_tools/deviation_evaluator/src/deviation_evaluator.cpp
@@ -44,6 +44,8 @@ DeviationEvaluator::DeviationEvaluator(
   period_ = declare_parameter("period", 10.0);
   cut_ = declare_parameter("cut", 9.0);
   save_dir_ = declare_parameter("save_dir", "");
+  vx_threshold_ = declare_parameter<double>("vx_threshold");
+  wz_threshold_ = declare_parameter<double>("wz_threshold");
 
   save2YamlFile();
 
@@ -80,6 +82,10 @@ void DeviationEvaluator::callbackTwistWithCovariance(
   msg->twist.covariance[0 * 6 + 5] = 0.0;
   msg->twist.covariance[5 * 6 + 0] = 0.0;
   msg->twist.covariance[5 * 6 + 5] = stddev_wz_ * stddev_wz_;
+  if (msg->twist.twist.linear.x < vx_threshold_ && msg->twist.twist.angular.z < wz_threshold_) {
+    msg->twist.twist.linear.x = 0.0;
+    msg->twist.twist.angular.z = 0.0;
+  }
   pub_twist_with_cov_->publish(*msg);
 }
 


### PR DESCRIPTION
Signed-off-by: kminoda <koji.minoda@tier4.jp>

## Description
I want to use twist_with_covariance_raw as a twist input in `deviation_evaluator`. 

The previous one used twist_with_covariance, which is already applied a stop filter in `gyro_odometer`. Since we are cancelling the offset in `deviation_evaluator`, the yaw rate won't become zero when the vehicle is stopped due to the offset (which is weird). 
<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
