### PR TITLE
feat(deviation_evaluator): add initial trigger for the latest ekf_localizer

### DIFF
--- a/localization/deviation_estimation_tools/deviation_evaluator/config/deviation_evaluator.param.yaml
+++ b/localization/deviation_estimation_tools/deviation_evaluator/config/deviation_evaluator.param.yaml
@@ -9,3 +9,5 @@
     # Dead Reckoning configuration
     period: 10.0 # [s]
     cut: 9.0 # [s]
+
+    need_ekf_initial_trigger: false

--- a/localization/deviation_estimation_tools/deviation_evaluator/include/deviation_evaluator/deviation_evaluator.hpp
+++ b/localization/deviation_estimation_tools/deviation_evaluator/include/deviation_evaluator/deviation_evaluator.hpp
@@ -26,6 +26,7 @@
 #include "sensor_msgs/msg/imu.hpp"
 #include "std_msgs/msg/float64.hpp"
 #include "tier4_debug_msgs/msg/float64_stamped.hpp"
+#include "std_srvs/srv/set_bool.hpp"
 
 #include <fstream>
 #include <iostream>
@@ -51,6 +52,9 @@ private:
   rclcpp::Publisher<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr pub_pose_with_cov_gt_;
   rclcpp::Publisher<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr
     pub_init_pose_with_cov_;
+
+  rclcpp::Client<std_srvs::srv::SetBool>::SharedPtr client_trigger_ekf_dr_;
+  rclcpp::Client<std_srvs::srv::SetBool>::SharedPtr client_trigger_ekf_gt_;
 
   bool show_debug_info_;
   std::string save_dir_;

--- a/localization/deviation_estimation_tools/deviation_evaluator/include/deviation_evaluator/deviation_evaluator.hpp
+++ b/localization/deviation_estimation_tools/deviation_evaluator/include/deviation_evaluator/deviation_evaluator.hpp
@@ -16,6 +16,7 @@
 #define DEVIATION_EVALUATOR__DEVIATION_EVALUATOR_HPP_
 
 #include "rclcpp/rclcpp.hpp"
+#include "std_srvs/srv/set_bool.hpp"
 #include "tf2/LinearMath/Quaternion.h"
 #include "tf2/utils.h"
 
@@ -26,7 +27,6 @@
 #include "sensor_msgs/msg/imu.hpp"
 #include "std_msgs/msg/float64.hpp"
 #include "tier4_debug_msgs/msg/float64_stamped.hpp"
-#include "std_srvs/srv/set_bool.hpp"
 
 #include <fstream>
 #include <iostream>

--- a/localization/deviation_estimation_tools/deviation_evaluator/launch/deviation_evaluator.launch.xml
+++ b/localization/deviation_estimation_tools/deviation_evaluator/launch/deviation_evaluator.launch.xml
@@ -11,6 +11,8 @@
   <arg name="in_wheel_odometry" default="/sensing/vehicle_velocity_converter/twist_with_covariance"/>
   <arg name="in_ndt_pose_with_covariance" default="/localization/pose_estimator/pose_with_covariance"/>
 
+  <arg name="out_ekf_dr_trigger" default="/deviation_evaluator/ekf_dr_trigger"/>
+  <arg name="out_ekf_gt_trigger" default="/deviation_evaluator/ekf_gt_trigger"/>
   <arg name="out_imu" default="/deviation_evaluator/imu/imu_data"/>
   <arg name="out_wheel_odometry" default="/deviation_evaluator/vehicle_velocity_converter/twist_with_covariance"/>
   <arg name="out_ekf_odom_dr" default="/deviation_evaluator/dead_reckoning/ekf_localizer/kinematic_state"/>
@@ -33,6 +35,8 @@
       <remap from="out_pose_with_covariance_dr" to="$(var out_pose_with_covariance_dr)"/>
       <remap from="out_pose_with_covariance_gt" to="$(var out_pose_with_covariance_gt)"/>
       <remap from="out_initial_pose_with_covariance" to="$(var out_init_pose_with_covariance)"/>
+      <remap from="out_ekf_dr_trigger" to="$(var out_ekf_dr_trigger)"/>
+      <remap from="out_ekf_gt_trigger" to="$(var out_ekf_gt_trigger)"/>
 
       <param name="save_dir" value="$(var save_dir)"/>
       <param from="$(var param_path)"/>
@@ -54,6 +58,7 @@
       <arg name="input_twist_with_cov_name" value="$(var out_twist_with_covariance)"/>
       <arg name="input_initial_pose_name" value="$(var out_init_pose_with_covariance)"/>
       <arg name="output_odom_name" value="$(var out_ekf_odom_dr)"/>
+      <arg name="input_trigger_node_service_name" value="$(var out_ekf_dr_trigger)"/>
 
       <arg name="proc_stddev_vx_c" value="10.0"/>
       <arg name="proc_stddev_wz_c" value="5.0"/>
@@ -67,6 +72,7 @@
       <arg name="input_twist_with_cov_name" value="$(var out_twist_with_covariance)"/>
       <arg name="input_initial_pose_name" value="$(var out_init_pose_with_covariance)"/>
       <arg name="output_odom_name" value="$(var out_ekf_odom_gt)"/>
+      <arg name="input_trigger_node_service_name" value="$(var out_ekf_gt_trigger)"/>
 
       <arg name="proc_stddev_vx_c" value="10.0"/>
       <arg name="proc_stddev_wz_c" value="5.0"/>

--- a/localization/deviation_estimation_tools/deviation_evaluator/package.xml
+++ b/localization/deviation_estimation_tools/deviation_evaluator/package.xml
@@ -15,6 +15,7 @@
   <depend>rclpy</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
+  <depend>std_srvs</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
   <depend>tier4_debug_msgs</depend>

--- a/localization/deviation_estimation_tools/deviation_evaluator/src/deviation_evaluator.cpp
+++ b/localization/deviation_estimation_tools/deviation_evaluator/src/deviation_evaluator.cpp
@@ -30,6 +30,8 @@
 // clang-format on
 using std::placeholders::_1;
 
+using namespace std::chrono_literals;
+
 double double_round(const double x, const int n) { return std::round(x * pow(10, n)) / pow(10, n); }
 
 DeviationEvaluator::DeviationEvaluator(
@@ -44,6 +46,32 @@ DeviationEvaluator::DeviationEvaluator(
   period_ = declare_parameter("period", 10.0);
   cut_ = declare_parameter("cut", 9.0);
   save_dir_ = declare_parameter("save_dir", "");
+
+  client_trigger_ekf_dr_ = create_client<std_srvs::srv::SetBool>("out_ekf_dr_trigger", rmw_qos_profile_services_default);
+  client_trigger_ekf_gt_ = create_client<std_srvs::srv::SetBool>("out_ekf_gt_trigger", rmw_qos_profile_services_default);
+
+  if (declare_parameter<bool>("need_ekf_initial_trigger"))
+  {
+    while (!client_trigger_ekf_dr_->wait_for_service(1s)) {
+      if (!rclcpp::ok()) break;
+      RCLCPP_INFO_STREAM(this->get_logger(), "Waiting for EKF trigger service...");
+    }
+    auto req = std::make_shared<std_srvs::srv::SetBool::Request>();
+    client_trigger_ekf_dr_->async_send_request(
+      req,
+      [this]([[maybe_unused]] rclcpp::Client<std_srvs::srv::SetBool>::SharedFuture result) {}
+    );
+
+    while (!client_trigger_ekf_gt_->wait_for_service(1s)) {
+      if (!rclcpp::ok()) break;
+      RCLCPP_INFO_STREAM(this->get_logger(), "Waiting for EKF trigger service...");
+    }
+    client_trigger_ekf_gt_->async_send_request(
+      req,
+      [this]([[maybe_unused]] rclcpp::Client<std_srvs::srv::SetBool>::SharedFuture result) {}
+    );
+    RCLCPP_INFO(this->get_logger(), "EKF initialization finished");
+  }
 
   save2YamlFile();
 

--- a/localization/deviation_estimation_tools/deviation_evaluator/src/deviation_evaluator.cpp
+++ b/localization/deviation_estimation_tools/deviation_evaluator/src/deviation_evaluator.cpp
@@ -47,29 +47,26 @@ DeviationEvaluator::DeviationEvaluator(
   cut_ = declare_parameter("cut", 9.0);
   save_dir_ = declare_parameter("save_dir", "");
 
-  client_trigger_ekf_dr_ = create_client<std_srvs::srv::SetBool>("out_ekf_dr_trigger", rmw_qos_profile_services_default);
-  client_trigger_ekf_gt_ = create_client<std_srvs::srv::SetBool>("out_ekf_gt_trigger", rmw_qos_profile_services_default);
+  client_trigger_ekf_dr_ =
+    create_client<std_srvs::srv::SetBool>("out_ekf_dr_trigger", rmw_qos_profile_services_default);
+  client_trigger_ekf_gt_ =
+    create_client<std_srvs::srv::SetBool>("out_ekf_gt_trigger", rmw_qos_profile_services_default);
 
-  if (declare_parameter<bool>("need_ekf_initial_trigger"))
-  {
+  if (declare_parameter<bool>("need_ekf_initial_trigger")) {
     while (!client_trigger_ekf_dr_->wait_for_service(1s)) {
       if (!rclcpp::ok()) break;
       RCLCPP_INFO_STREAM(this->get_logger(), "Waiting for EKF trigger service...");
     }
     auto req = std::make_shared<std_srvs::srv::SetBool::Request>();
     client_trigger_ekf_dr_->async_send_request(
-      req,
-      [this]([[maybe_unused]] rclcpp::Client<std_srvs::srv::SetBool>::SharedFuture result) {}
-    );
+      req, [this]([[maybe_unused]] rclcpp::Client<std_srvs::srv::SetBool>::SharedFuture result) {});
 
     while (!client_trigger_ekf_gt_->wait_for_service(1s)) {
       if (!rclcpp::ok()) break;
       RCLCPP_INFO_STREAM(this->get_logger(), "Waiting for EKF trigger service...");
     }
     client_trigger_ekf_gt_->async_send_request(
-      req,
-      [this]([[maybe_unused]] rclcpp::Client<std_srvs::srv::SetBool>::SharedFuture result) {}
-    );
+      req, [this]([[maybe_unused]] rclcpp::Client<std_srvs::srv::SetBool>::SharedFuture result) {});
     RCLCPP_INFO(this->get_logger(), "EKF initialization finished");
   }
 


### PR DESCRIPTION
Signed-off-by: kminoda <koji.minoda@tier4.jp>

## Description
Since the latest EKF requires initial trigger (with ROS2 client), I added an option for triggering EKF in deviation_evaluator.
<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
