### PR TITLE
feat(deviation_estimator): add distance validation

### DIFF
--- a/localization/deviation_estimation_tools/deviation_estimator/CMakeLists.txt
+++ b/localization/deviation_estimation_tools/deviation_estimator/CMakeLists.txt
@@ -10,6 +10,8 @@ ament_auto_add_library(deviation_estimator_lib SHARED
   src/utils.cpp
   src/gyro_bias_module.cpp
   src/velocity_coef_module.cpp
+  src/data_validation_module.cpp
+  src/write_result_file.cpp
 )
 
 ament_auto_add_executable(deviation_estimator src/deviation_estimator_node.cpp)

--- a/localization/deviation_estimation_tools/deviation_estimator/config/deviation_estimator.param.yaml
+++ b/localization/deviation_estimation_tools/deviation_estimator/config/deviation_estimator.param.yaml
@@ -1,3 +1,6 @@
 /**:
   ros__parameters:
     time_window: 2.0
+
+    # Parameters for data validation
+    distance_travelled_threshold: 100.0

--- a/localization/deviation_estimation_tools/deviation_estimator/include/deviation_estimator/data_validation_module.hpp
+++ b/localization/deviation_estimation_tools/deviation_estimator/include/deviation_estimator/data_validation_module.hpp
@@ -1,0 +1,37 @@
+// Copyright 2018-2019 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DEVIATION_ESTIMATOR__DATA_VALIDATION_MODULE_HPP_
+#define DEVIATION_ESTIMATOR__DATA_VALIDATION_MODULE_HPP_
+
+#include "geometry_msgs/msg/pose_stamped.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+#include <memory>
+
+class DataValidationModule
+{
+public:
+  DataValidationModule(rclcpp::Node * node);
+  void update_pose(const geometry_msgs::msg::PoseStamped & pose);
+  bool is_data_valid();
+
+private:
+  geometry_msgs::msg::PoseStamped::SharedPtr latest_pose_ptr_;
+  double distance_travelled_;
+
+  const double distance_travelled_threshold_;
+};
+
+#endif  // DEVIATION_ESTIMATOR__DATA_VALIDATION_MODULE_HPP_

--- a/localization/deviation_estimation_tools/deviation_estimator/include/deviation_estimator/data_validation_module.hpp
+++ b/localization/deviation_estimation_tools/deviation_estimator/include/deviation_estimator/data_validation_module.hpp
@@ -15,8 +15,9 @@
 #ifndef DEVIATION_ESTIMATOR__DATA_VALIDATION_MODULE_HPP_
 #define DEVIATION_ESTIMATOR__DATA_VALIDATION_MODULE_HPP_
 
-#include "geometry_msgs/msg/pose_stamped.hpp"
 #include "rclcpp/rclcpp.hpp"
+
+#include "geometry_msgs/msg/pose_stamped.hpp"
 
 #include <memory>
 

--- a/localization/deviation_estimation_tools/deviation_estimator/include/deviation_estimator/deviation_estimator.hpp
+++ b/localization/deviation_estimation_tools/deviation_estimator/include/deviation_estimator/deviation_estimator.hpp
@@ -15,10 +15,10 @@
 #ifndef DEVIATION_ESTIMATOR__DEVIATION_ESTIMATOR_HPP_
 #define DEVIATION_ESTIMATOR__DEVIATION_ESTIMATOR_HPP_
 
+#include "deviation_estimator/data_validation_module.hpp"
 #include "deviation_estimator/gyro_bias_module.hpp"
 #include "deviation_estimator/utils.hpp"
 #include "deviation_estimator/velocity_coef_module.hpp"
-#include "deviation_estimator/data_validation_module.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "tf2/utils.h"
 #include "tier4_autoware_utils/ros/transform_listener.hpp"

--- a/localization/deviation_estimation_tools/deviation_estimator/include/deviation_estimator/deviation_estimator.hpp
+++ b/localization/deviation_estimation_tools/deviation_estimator/include/deviation_estimator/deviation_estimator.hpp
@@ -18,6 +18,7 @@
 #include "deviation_estimator/gyro_bias_module.hpp"
 #include "deviation_estimator/utils.hpp"
 #include "deviation_estimator/velocity_coef_module.hpp"
+#include "deviation_estimator/data_validation_module.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "tf2/utils.h"
 #include "tier4_autoware_utils/ros/transform_listener.hpp"
@@ -95,6 +96,7 @@ private:
 
   std::unique_ptr<GyroBiasModule> gyro_bias_module_;
   std::unique_ptr<VelocityCoefModule> vel_coef_module_;
+  std::unique_ptr<DataValidationModule> data_validation_module_;
 
   std::shared_ptr<tier4_autoware_utils::TransformListener> transform_listener_;
 

--- a/localization/deviation_estimation_tools/deviation_estimator/include/deviation_estimator/utils.hpp
+++ b/localization/deviation_estimation_tools/deviation_estimator/include/deviation_estimator/utils.hpp
@@ -24,7 +24,6 @@
 
 #include <tf2/transform_datatypes.h>
 
-#include <fstream>
 #include <vector>
 
 #ifdef ROS_DISTRO_GALACTIC
@@ -33,8 +32,6 @@
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #endif
 #include "tf2/utils.h"
-
-double double_round(const double x, const int n);
 
 template <typename T>
 double calculate_mean(const std::vector<T> & v)
@@ -148,12 +145,6 @@ double norm_xy(const T p1, const U p2)
 }
 
 double clip_radian(const double rad);
-
-void save_estimated_parameters(
-  const std::string output_path, const double stddev_vx, const double stddev_wz,
-  const double coef_vx, const double bias_wz,
-  const geometry_msgs::msg::Vector3 & angular_velocity_stddev,
-  const geometry_msgs::msg::Vector3 & angular_velocity_offset);
 
 geometry_msgs::msg::Point integrate_position(
   const std::vector<tier4_debug_msgs::msg::Float64Stamped> & vx_list,

--- a/localization/deviation_estimation_tools/deviation_estimator/include/deviation_estimator/write_result_file.hpp
+++ b/localization/deviation_estimation_tools/deviation_estimator/include/deviation_estimator/write_result_file.hpp
@@ -1,0 +1,45 @@
+// Copyright 2018-2019 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DEVIATION_ESTIMATOR__WRITE_RESULT_FILE_HPP_
+#define DEVIATION_ESTIMATOR__WRITE_RESULT_FILE_HPP_
+
+#include "geometry_msgs/msg/vector3.hpp"
+
+#include <string>
+#include <fstream>
+#include <fmt/core.h>
+
+void save_estimated_result(
+  const std::string output_path, const double stddev_vx, const double stddev_wz,
+  const double coef_vx, const double bias_wz,
+  const geometry_msgs::msg::Vector3 & angular_velocity_stddev,
+  const geometry_msgs::msg::Vector3 & angular_velocity_offset);
+
+void save_estimated_result(
+  const std::string output_path, const double stddev_vx, const double stddev_wz,
+  const double coef_vx, const double bias_wz,
+  const geometry_msgs::msg::Vector3 & angular_velocity_stddev,
+  const geometry_msgs::msg::Vector3 & angular_velocity_offset,
+  const bool is_distance_valid);
+
+std::string generate_estimation_section(
+  const double stddev_vx, const double stddev_wz,
+  const double coef_vx, const double bias_wz,
+  const geometry_msgs::msg::Vector3 & angular_velocity_stddev,
+  const geometry_msgs::msg::Vector3 & angular_velocity_offset);
+
+std::string generate_validation_section(const bool is_distance_valid);
+
+#endif  // DEVIATION_ESTIMATOR__WRITE_RESULT_FILE_HPP_

--- a/localization/deviation_estimation_tools/deviation_estimator/include/deviation_estimator/write_result_file.hpp
+++ b/localization/deviation_estimation_tools/deviation_estimator/include/deviation_estimator/write_result_file.hpp
@@ -17,9 +17,10 @@
 
 #include "geometry_msgs/msg/vector3.hpp"
 
-#include <string>
-#include <fstream>
 #include <fmt/core.h>
+
+#include <fstream>
+#include <string>
 
 void save_estimated_result(
   const std::string output_path, const double stddev_vx, const double stddev_wz,
@@ -31,12 +32,10 @@ void save_estimated_result(
   const std::string output_path, const double stddev_vx, const double stddev_wz,
   const double coef_vx, const double bias_wz,
   const geometry_msgs::msg::Vector3 & angular_velocity_stddev,
-  const geometry_msgs::msg::Vector3 & angular_velocity_offset,
-  const bool is_distance_valid);
+  const geometry_msgs::msg::Vector3 & angular_velocity_offset, const bool is_distance_valid);
 
 std::string generate_estimation_section(
-  const double stddev_vx, const double stddev_wz,
-  const double coef_vx, const double bias_wz,
+  const double stddev_vx, const double stddev_wz, const double coef_vx, const double bias_wz,
   const geometry_msgs::msg::Vector3 & angular_velocity_stddev,
   const geometry_msgs::msg::Vector3 & angular_velocity_offset);
 

--- a/localization/deviation_estimation_tools/deviation_estimator/package.xml
+++ b/localization/deviation_estimation_tools/deviation_estimator/package.xml
@@ -15,6 +15,7 @@
   <depend>rclcpp</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
+  <depend>fmt</depend>
   <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>

--- a/localization/deviation_estimation_tools/deviation_estimator/package.xml
+++ b/localization/deviation_estimation_tools/deviation_estimator/package.xml
@@ -10,12 +10,12 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <build_depend>autoware_cmake</build_depend>
 
+  <depend>fmt</depend>
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>rclcpp</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
-  <depend>fmt</depend>
   <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>

--- a/localization/deviation_estimation_tools/deviation_estimator/src/data_validation_module.cpp
+++ b/localization/deviation_estimation_tools/deviation_estimator/src/data_validation_module.cpp
@@ -1,0 +1,37 @@
+// Copyright 2018-2019 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "deviation_estimator/data_validation_module.hpp"
+#include "deviation_estimator/utils.hpp"
+#include "tier4_autoware_utils/geometry/geometry.hpp"
+
+DataValidationModule::DataValidationModule(rclcpp::Node * node)
+: distance_travelled_(0.0),
+  distance_travelled_threshold_(node->declare_parameter<double>("distance_travelled_threshold"))
+{
+}
+
+void DataValidationModule::update_pose(
+  const geometry_msgs::msg::PoseStamped & pose)
+{
+  distance_travelled_ += norm_xy(pose.pose.position, latest_pose_ptr_->pose.position);
+  latest_pose_ptr_ = std::make_shared<geometry_msgs::msg::PoseStamped>(pose);
+}
+
+bool DataValidationModule::is_data_valid()
+{
+  bool is_travelled_distance_valid = distance_travelled_threshold_ < distance_travelled_;
+
+  return is_travelled_distance_valid;
+}

--- a/localization/deviation_estimation_tools/deviation_estimator/src/data_validation_module.cpp
+++ b/localization/deviation_estimation_tools/deviation_estimator/src/data_validation_module.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "deviation_estimator/data_validation_module.hpp"
+
 #include "deviation_estimator/utils.hpp"
 #include "tier4_autoware_utils/geometry/geometry.hpp"
 
@@ -22,8 +23,7 @@ DataValidationModule::DataValidationModule(rclcpp::Node * node)
 {
 }
 
-void DataValidationModule::update_pose(
-  const geometry_msgs::msg::PoseStamped & pose)
+void DataValidationModule::update_pose(const geometry_msgs::msg::PoseStamped & pose)
 {
   distance_travelled_ += norm_xy(pose.pose.position, latest_pose_ptr_->pose.position);
   latest_pose_ptr_ = std::make_shared<geometry_msgs::msg::PoseStamped>(pose);

--- a/localization/deviation_estimation_tools/deviation_estimator/src/deviation_estimator.cpp
+++ b/localization/deviation_estimation_tools/deviation_estimator/src/deviation_estimator.cpp
@@ -13,8 +13,9 @@
 // limitations under the License.
 
 #include "deviation_estimator/deviation_estimator.hpp"
-#include "deviation_estimator/write_result_file.hpp"
+
 #include "deviation_estimator/utils.hpp"
+#include "deviation_estimator/write_result_file.hpp"
 #include "rclcpp/logging.hpp"
 #include "tier4_autoware_utils/geometry/geometry.hpp"
 
@@ -286,12 +287,8 @@ void DeviationEstimator::timer_callback()
 
   if (!results_path_.empty()) {
     save_estimated_result(
-      results_path_,
-      stddev_vx, stddev_angvel_base.z,
-      vel_coef_module_->get_coef(),
-      gyro_bias_module_->get_bias_base_link().z,
-      stddev_angvel_imu_msg,
-      bias_angvel_imu,
+      results_path_, stddev_vx, stddev_angvel_base.z, vel_coef_module_->get_coef(),
+      gyro_bias_module_->get_bias_base_link().z, stddev_angvel_imu_msg, bias_angvel_imu,
       data_validation_module_->is_data_valid());
   }
 }

--- a/localization/deviation_estimation_tools/deviation_estimator/src/utils.cpp
+++ b/localization/deviation_estimation_tools/deviation_estimator/src/utils.cpp
@@ -23,8 +23,6 @@
 #include <iostream>
 #include <vector>
 
-double double_round(const double x, const int n) { return std::round(x * pow(10, n)) / pow(10, n); }
-
 double clip_radian(const double rad)
 {
   if (rad < -M_PI) {
@@ -34,35 +32,6 @@ double clip_radian(const double rad)
   } else {
     return rad;
   }
-}
-
-/*
- * save_estimated_parameters
- */
-void save_estimated_parameters(
-  const std::string output_path, const double stddev_vx, const double stddev_wz,
-  const double coef_vx, const double bias_wz,
-  const geometry_msgs::msg::Vector3 & angular_velocity_stddev,
-  const geometry_msgs::msg::Vector3 & angular_velocity_offset)
-{
-  std::ofstream file(output_path);
-  file << "# Results expressed in base_link" << std::endl;
-  file << "# Copy the following to deviation_evaluator.param.yaml" << std::endl;
-  file << "stddev_vx: " << double_round(stddev_vx, 5) << std::endl;
-  file << "stddev_wz: " << double_round(stddev_wz, 5) << std::endl;
-  file << "coef_vx: " << double_round(coef_vx, 5) << std::endl;
-  file << "bias_wz: " << double_round(bias_wz, 5) << std::endl;
-  file << std::endl;
-  file << "# Results expressed in imu_link" << std::endl;
-  file << "# Copy the following to imu_corrector.param.yaml" << std::endl;
-  file << "angular_velocity_stddev_xx: " << double_round(angular_velocity_stddev.x, 5) << std::endl;
-  file << "angular_velocity_stddev_yy: " << double_round(angular_velocity_stddev.y, 5) << std::endl;
-  file << "angular_velocity_stddev_zz: " << double_round(angular_velocity_stddev.z, 5) << std::endl;
-  file << "angular_velocity_offset_x: " << double_round(angular_velocity_offset.x, 6) << std::endl;
-  file << "angular_velocity_offset_y: " << double_round(angular_velocity_offset.y, 6) << std::endl;
-  file << "angular_velocity_offset_z: " << double_round(angular_velocity_offset.z, 6) << std::endl;
-
-  file.close();
 }
 
 geometry_msgs::msg::Vector3 interpolate_vector3_stamped(

--- a/localization/deviation_estimation_tools/deviation_estimator/src/write_result_file.cpp
+++ b/localization/deviation_estimation_tools/deviation_estimator/src/write_result_file.cpp
@@ -16,7 +16,10 @@
 
 #include <cmath>
 
-double double_round(const double x, const int n) { return std::round(x * std::pow(10, n)) / std::pow(10, n); }
+double double_round(const double x, const int n)
+{
+  return std::round(x * std::pow(10, n)) / std::pow(10, n);
+}
 
 void save_estimated_result(
   const std::string output_path, const double stddev_vx, const double stddev_wz,
@@ -25,7 +28,8 @@ void save_estimated_result(
   const geometry_msgs::msg::Vector3 & angular_velocity_offset)
 {
   std::ofstream file(output_path);
-  file << generate_estimation_section(stddev_vx, stddev_wz, coef_vx, bias_wz, angular_velocity_stddev, angular_velocity_offset);
+  file << generate_estimation_section(
+    stddev_vx, stddev_wz, coef_vx, bias_wz, angular_velocity_stddev, angular_velocity_offset);
   file.close();
 }
 
@@ -33,19 +37,18 @@ void save_estimated_result(
   const std::string output_path, const double stddev_vx, const double stddev_wz,
   const double coef_vx, const double bias_wz,
   const geometry_msgs::msg::Vector3 & angular_velocity_stddev,
-  const geometry_msgs::msg::Vector3 & angular_velocity_offset,
-  const bool is_distance_valid)
+  const geometry_msgs::msg::Vector3 & angular_velocity_offset, const bool is_distance_valid)
 {
   std::ofstream file(output_path);
   file << generate_validation_section(is_distance_valid);
   file << "\n";
-  file << generate_estimation_section(stddev_vx, stddev_wz, coef_vx, bias_wz, angular_velocity_stddev, angular_velocity_offset);
+  file << generate_estimation_section(
+    stddev_vx, stddev_wz, coef_vx, bias_wz, angular_velocity_stddev, angular_velocity_offset);
   file.close();
 }
 
 std::string generate_estimation_section(
-  const double stddev_vx, const double stddev_wz,
-  const double coef_vx, const double bias_wz,
+  const double stddev_vx, const double stddev_wz, const double coef_vx, const double bias_wz,
   const geometry_msgs::msg::Vector3 & angular_velocity_stddev,
   const geometry_msgs::msg::Vector3 & angular_velocity_offset)
 {
@@ -59,12 +62,18 @@ std::string generate_estimation_section(
   output_string += "\n";
   output_string += "# Results expressed in imu_link\n";
   output_string += "# Copy the following to imu_corrector.param.yaml\n";
-  output_string += fmt::format("angular_velocity_stddev_xx: {}\n", double_round(angular_velocity_stddev.x, 5));
-  output_string += fmt::format("angular_velocity_stddev_yy: {}\n", double_round(angular_velocity_stddev.y, 5));
-  output_string += fmt::format("angular_velocity_stddev_zz: {}\n", double_round(angular_velocity_stddev.z, 5));
-  output_string += fmt::format("angular_velocity_offset_x: {}\n", double_round(angular_velocity_offset.x, 5));
-  output_string += fmt::format("angular_velocity_offset_y: {}\n", double_round(angular_velocity_offset.y, 5));
-  output_string += fmt::format("angular_velocity_offset_z: {}\n", double_round(angular_velocity_offset.z, 5));
+  output_string +=
+    fmt::format("angular_velocity_stddev_xx: {}\n", double_round(angular_velocity_stddev.x, 5));
+  output_string +=
+    fmt::format("angular_velocity_stddev_yy: {}\n", double_round(angular_velocity_stddev.y, 5));
+  output_string +=
+    fmt::format("angular_velocity_stddev_zz: {}\n", double_round(angular_velocity_stddev.z, 5));
+  output_string +=
+    fmt::format("angular_velocity_offset_x: {}\n", double_round(angular_velocity_offset.x, 5));
+  output_string +=
+    fmt::format("angular_velocity_offset_y: {}\n", double_round(angular_velocity_offset.y, 5));
+  output_string +=
+    fmt::format("angular_velocity_offset_z: {}\n", double_round(angular_velocity_offset.z, 5));
   return output_string;
 }
 

--- a/localization/deviation_estimation_tools/deviation_estimator/src/write_result_file.cpp
+++ b/localization/deviation_estimation_tools/deviation_estimator/src/write_result_file.cpp
@@ -1,0 +1,84 @@
+// Copyright 2018-2019 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "deviation_estimator/write_result_file.hpp"
+
+#include <cmath>
+
+double double_round(const double x, const int n) { return std::round(x * std::pow(10, n)) / std::pow(10, n); }
+
+void save_estimated_result(
+  const std::string output_path, const double stddev_vx, const double stddev_wz,
+  const double coef_vx, const double bias_wz,
+  const geometry_msgs::msg::Vector3 & angular_velocity_stddev,
+  const geometry_msgs::msg::Vector3 & angular_velocity_offset)
+{
+  std::ofstream file(output_path);
+  file << generate_estimation_section(stddev_vx, stddev_wz, coef_vx, bias_wz, angular_velocity_stddev, angular_velocity_offset);
+  file.close();
+}
+
+void save_estimated_result(
+  const std::string output_path, const double stddev_vx, const double stddev_wz,
+  const double coef_vx, const double bias_wz,
+  const geometry_msgs::msg::Vector3 & angular_velocity_stddev,
+  const geometry_msgs::msg::Vector3 & angular_velocity_offset,
+  const bool is_distance_valid)
+{
+  std::ofstream file(output_path);
+  file << generate_validation_section(is_distance_valid);
+  file << "\n";
+  file << generate_estimation_section(stddev_vx, stddev_wz, coef_vx, bias_wz, angular_velocity_stddev, angular_velocity_offset);
+  file.close();
+}
+
+std::string generate_estimation_section(
+  const double stddev_vx, const double stddev_wz,
+  const double coef_vx, const double bias_wz,
+  const geometry_msgs::msg::Vector3 & angular_velocity_stddev,
+  const geometry_msgs::msg::Vector3 & angular_velocity_offset)
+{
+  std::string output_string;
+  output_string += "# Results expressed in base_link\n";
+  output_string += "# Copy the following to deviation_evaluator.param.yaml\n";
+  output_string += fmt::format("stddev_vx: {}\n", double_round(stddev_vx, 5));
+  output_string += fmt::format("stddev_wz: {}\n", double_round(stddev_wz, 5));
+  output_string += fmt::format("coef_vx: {}\n", double_round(coef_vx, 5));
+  output_string += fmt::format("bias_wz: {}\n", double_round(bias_wz, 5));
+  output_string += "\n";
+  output_string += "# Results expressed in imu_link\n";
+  output_string += "# Copy the following to imu_corrector.param.yaml\n";
+  output_string += fmt::format("angular_velocity_stddev_xx: {}\n", double_round(angular_velocity_stddev.x, 5));
+  output_string += fmt::format("angular_velocity_stddev_yy: {}\n", double_round(angular_velocity_stddev.y, 5));
+  output_string += fmt::format("angular_velocity_stddev_zz: {}\n", double_round(angular_velocity_stddev.z, 5));
+  output_string += fmt::format("angular_velocity_offset_x: {}\n", double_round(angular_velocity_offset.x, 5));
+  output_string += fmt::format("angular_velocity_offset_y: {}\n", double_round(angular_velocity_offset.y, 5));
+  output_string += fmt::format("angular_velocity_offset_z: {}\n", double_round(angular_velocity_offset.z, 5));
+  return output_string;
+}
+
+std::string generate_validation_section(const bool is_distance_valid)
+{
+  std::string output_string;
+  output_string += "##########################################################################\n";
+  output_string += "# Validation results:\n";
+
+  if (is_distance_valid) {
+    output_string += "#   - Travelled distance: OK\n";
+  } else {
+    output_string += "#   - Travelled distance: NG (Provide more data for valid estimation.)\n";
+  }
+  output_string += "##########################################################################\n";
+  return output_string;
+}

--- a/localization/deviation_estimation_tools/deviation_evaluator/include/deviation_evaluator/deviation_evaluator.hpp
+++ b/localization/deviation_estimation_tools/deviation_evaluator/include/deviation_evaluator/deviation_evaluator.hpp
@@ -26,6 +26,7 @@
 #include "sensor_msgs/msg/imu.hpp"
 #include "std_msgs/msg/float64.hpp"
 #include "tier4_debug_msgs/msg/float64_stamped.hpp"
+#include "std_srvs/srv/set_bool.hpp"
 
 #include <fstream>
 #include <iostream>
@@ -51,6 +52,9 @@ private:
   rclcpp::Publisher<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr pub_pose_with_cov_gt_;
   rclcpp::Publisher<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr
     pub_init_pose_with_cov_;
+
+  rclcpp::Client<std_srvs::srv::SetBool>::SharedPtr client_trigger_ekf_dr_;
+  rclcpp::Client<std_srvs::srv::SetBool>::SharedPtr client_trigger_ekf_gt_;
 
   bool show_debug_info_;
   std::string save_dir_;

--- a/localization/deviation_estimation_tools/deviation_evaluator/include/deviation_evaluator/deviation_evaluator.hpp
+++ b/localization/deviation_estimation_tools/deviation_evaluator/include/deviation_evaluator/deviation_evaluator.hpp
@@ -16,6 +16,7 @@
 #define DEVIATION_EVALUATOR__DEVIATION_EVALUATOR_HPP_
 
 #include "rclcpp/rclcpp.hpp"
+#include "std_srvs/srv/set_bool.hpp"
 #include "tf2/LinearMath/Quaternion.h"
 #include "tf2/utils.h"
 
@@ -26,7 +27,6 @@
 #include "sensor_msgs/msg/imu.hpp"
 #include "std_msgs/msg/float64.hpp"
 #include "tier4_debug_msgs/msg/float64_stamped.hpp"
-#include "std_srvs/srv/set_bool.hpp"
 
 #include <fstream>
 #include <iostream>

--- a/localization/deviation_estimation_tools/deviation_evaluator/launch/deviation_evaluator.launch.xml
+++ b/localization/deviation_estimation_tools/deviation_evaluator/launch/deviation_evaluator.launch.xml
@@ -11,6 +11,8 @@
   <arg name="in_wheel_odometry" default="/sensing/vehicle_velocity_converter/twist_with_covariance"/>
   <arg name="in_ndt_pose_with_covariance" default="/localization/pose_estimator/pose_with_covariance"/>
 
+  <arg name="out_ekf_dr_trigger" default="/deviation_evaluator/ekf_dr_trigger"/>
+  <arg name="out_ekf_gt_trigger" default="/deviation_evaluator/ekf_gt_trigger"/>
   <arg name="out_imu" default="/deviation_evaluator/imu/imu_data"/>
   <arg name="out_wheel_odometry" default="/deviation_evaluator/vehicle_velocity_converter/twist_with_covariance"/>
   <arg name="out_ekf_odom_dr" default="/deviation_evaluator/dead_reckoning/ekf_localizer/kinematic_state"/>
@@ -33,6 +35,8 @@
       <remap from="out_pose_with_covariance_dr" to="$(var out_pose_with_covariance_dr)"/>
       <remap from="out_pose_with_covariance_gt" to="$(var out_pose_with_covariance_gt)"/>
       <remap from="out_initial_pose_with_covariance" to="$(var out_init_pose_with_covariance)"/>
+      <remap from="out_ekf_dr_trigger" to="$(var out_ekf_dr_trigger)"/>
+      <remap from="out_ekf_gt_trigger" to="$(var out_ekf_gt_trigger)"/>
 
       <param name="save_dir" value="$(var save_dir)"/>
       <param from="$(var param_path)"/>
@@ -54,6 +58,7 @@
       <arg name="input_twist_with_cov_name" value="$(var out_twist_with_covariance)"/>
       <arg name="input_initial_pose_name" value="$(var out_init_pose_with_covariance)"/>
       <arg name="output_odom_name" value="$(var out_ekf_odom_dr)"/>
+      <arg name="input_trigger_node_service_name" value="$(var out_ekf_dr_trigger)"/>
 
       <arg name="proc_stddev_vx_c" value="10.0"/>
       <arg name="proc_stddev_wz_c" value="5.0"/>
@@ -67,6 +72,7 @@
       <arg name="input_twist_with_cov_name" value="$(var out_twist_with_covariance)"/>
       <arg name="input_initial_pose_name" value="$(var out_init_pose_with_covariance)"/>
       <arg name="output_odom_name" value="$(var out_ekf_odom_gt)"/>
+      <arg name="input_trigger_node_service_name" value="$(var out_ekf_gt_trigger)"/>
 
       <arg name="proc_stddev_vx_c" value="10.0"/>
       <arg name="proc_stddev_wz_c" value="5.0"/>

--- a/localization/deviation_estimation_tools/deviation_evaluator/package.xml
+++ b/localization/deviation_estimation_tools/deviation_evaluator/package.xml
@@ -15,6 +15,7 @@
   <depend>rclpy</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
+  <depend>std_srvs</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
   <depend>tier4_debug_msgs</depend>

--- a/localization/deviation_estimation_tools/deviation_evaluator/src/deviation_evaluator.cpp
+++ b/localization/deviation_estimation_tools/deviation_evaluator/src/deviation_evaluator.cpp
@@ -30,6 +30,8 @@
 // clang-format on
 using std::placeholders::_1;
 
+using namespace std::chrono_literals;
+
 double double_round(const double x, const int n) { return std::round(x * pow(10, n)) / pow(10, n); }
 
 DeviationEvaluator::DeviationEvaluator(
@@ -44,6 +46,32 @@ DeviationEvaluator::DeviationEvaluator(
   period_ = declare_parameter("period", 10.0);
   cut_ = declare_parameter("cut", 9.0);
   save_dir_ = declare_parameter("save_dir", "");
+
+  client_trigger_ekf_dr_ = create_client<std_srvs::srv::SetBool>("out_ekf_dr_trigger", rmw_qos_profile_services_default);
+  client_trigger_ekf_gt_ = create_client<std_srvs::srv::SetBool>("out_ekf_gt_trigger", rmw_qos_profile_services_default);
+
+  if (declare_parameter<bool>("need_ekf_initial_trigger"))
+  {
+    while (!client_trigger_ekf_dr_->wait_for_service(1s)) {
+      if (!rclcpp::ok()) break;
+      RCLCPP_INFO_STREAM(this->get_logger(), "Waiting for EKF trigger service...");
+    }
+    auto req = std::make_shared<std_srvs::srv::SetBool::Request>();
+    client_trigger_ekf_dr_->async_send_request(
+      req,
+      [this]([[maybe_unused]] rclcpp::Client<std_srvs::srv::SetBool>::SharedFuture result) {}
+    );
+
+    while (!client_trigger_ekf_gt_->wait_for_service(1s)) {
+      if (!rclcpp::ok()) break;
+      RCLCPP_INFO_STREAM(this->get_logger(), "Waiting for EKF trigger service...");
+    }
+    client_trigger_ekf_gt_->async_send_request(
+      req,
+      [this]([[maybe_unused]] rclcpp::Client<std_srvs::srv::SetBool>::SharedFuture result) {}
+    );
+    RCLCPP_INFO(this->get_logger(), "EKF initialization finished");
+  }
 
   save2YamlFile();
 

--- a/localization/deviation_estimation_tools/deviation_evaluator/src/deviation_evaluator.cpp
+++ b/localization/deviation_estimation_tools/deviation_evaluator/src/deviation_evaluator.cpp
@@ -47,29 +47,26 @@ DeviationEvaluator::DeviationEvaluator(
   cut_ = declare_parameter("cut", 9.0);
   save_dir_ = declare_parameter("save_dir", "");
 
-  client_trigger_ekf_dr_ = create_client<std_srvs::srv::SetBool>("out_ekf_dr_trigger", rmw_qos_profile_services_default);
-  client_trigger_ekf_gt_ = create_client<std_srvs::srv::SetBool>("out_ekf_gt_trigger", rmw_qos_profile_services_default);
+  client_trigger_ekf_dr_ =
+    create_client<std_srvs::srv::SetBool>("out_ekf_dr_trigger", rmw_qos_profile_services_default);
+  client_trigger_ekf_gt_ =
+    create_client<std_srvs::srv::SetBool>("out_ekf_gt_trigger", rmw_qos_profile_services_default);
 
-  if (declare_parameter<bool>("need_ekf_initial_trigger"))
-  {
+  if (declare_parameter<bool>("need_ekf_initial_trigger")) {
     while (!client_trigger_ekf_dr_->wait_for_service(1s)) {
       if (!rclcpp::ok()) break;
       RCLCPP_INFO_STREAM(this->get_logger(), "Waiting for EKF trigger service...");
     }
     auto req = std::make_shared<std_srvs::srv::SetBool::Request>();
     client_trigger_ekf_dr_->async_send_request(
-      req,
-      [this]([[maybe_unused]] rclcpp::Client<std_srvs::srv::SetBool>::SharedFuture result) {}
-    );
+      req, [this]([[maybe_unused]] rclcpp::Client<std_srvs::srv::SetBool>::SharedFuture result) {});
 
     while (!client_trigger_ekf_gt_->wait_for_service(1s)) {
       if (!rclcpp::ok()) break;
       RCLCPP_INFO_STREAM(this->get_logger(), "Waiting for EKF trigger service...");
     }
     client_trigger_ekf_gt_->async_send_request(
-      req,
-      [this]([[maybe_unused]] rclcpp::Client<std_srvs::srv::SetBool>::SharedFuture result) {}
-    );
+      req, [this]([[maybe_unused]] rclcpp::Client<std_srvs::srv::SetBool>::SharedFuture result) {});
     RCLCPP_INFO(this->get_logger(), "EKF initialization finished");
   }
 


### PR DESCRIPTION
## Description
`deviation_estimator` outputs may be unstable when the amount of data is not enough, especially when the vehicle travel distance is not long enough. Here I add a validation module for validating if the travel distance is above threshold or not to notify the user when to terminate the estimation.
<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
