### PR TITLE
fix(deviation_evaluator): fix service message data

### DIFF
--- a/localization/deviation_estimation_tools/deviation_evaluator/src/deviation_evaluator.cpp
+++ b/localization/deviation_estimation_tools/deviation_evaluator/src/deviation_evaluator.cpp
@@ -58,6 +58,7 @@ DeviationEvaluator::DeviationEvaluator(
       RCLCPP_INFO_STREAM(this->get_logger(), "Waiting for EKF trigger service...");
     }
     auto req = std::make_shared<std_srvs::srv::SetBool::Request>();
+    req->data = true;
     client_trigger_ekf_dr_->async_send_request(
       req, [this]([[maybe_unused]] rclcpp::Client<std_srvs::srv::SetBool>::SharedFuture result) {});
 


### PR DESCRIPTION
Signed-off-by: Azumi Suzuki <azumi.suzuki@tier4.jp>

## Description

The service request data thrown to ekf_localizer needed to be `true`.
https://github.com/autowarefoundation/autoware.universe/blob/cc33997f75076a85d68838a31a95c82ce9cab1ef/localization/ekf_localizer/src/ekf_localizer.cpp#L681

<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
