### PR TITLE
fix(deviation_estimator): ekf initialization

### DIFF
--- a/localization/deviation_estimation_tools/deviation_evaluator/src/deviation_evaluator.cpp
+++ b/localization/deviation_estimation_tools/deviation_evaluator/src/deviation_evaluator.cpp
@@ -116,13 +116,13 @@ void DeviationEvaluator::callbackNDTPoseWithCovariance(
   if (!has_published_initial_pose_) {
     geometry_msgs::msg::PoseWithCovarianceStamped pose_with_cov;
     pose_with_cov = *msg;
-    pose_with_cov.pose.covariance[0] = 1.0;
-    pose_with_cov.pose.covariance[1 * 6 + 1] = 1.0;
+    pose_with_cov.pose.covariance[0 * 6 + 0] = 0.01;
+    pose_with_cov.pose.covariance[1 * 6 + 1] = 0.01;
     pose_with_cov.pose.covariance[2 * 6 + 2] = 0.01;
     pose_with_cov.pose.covariance[3 * 6 + 3] = 0.01;
     pose_with_cov.pose.covariance[4 * 6 + 4] = 0.01;
-    pose_with_cov.pose.covariance[5 * 6 + 5] = 0.2;
-    pub_init_pose_with_cov_->publish(*msg);
+    pose_with_cov.pose.covariance[5 * 6 + 5] = 0.01;
+    pub_init_pose_with_cov_->publish(pose_with_cov);
     has_published_initial_pose_ = true;
     return;
   }
@@ -137,6 +137,7 @@ void DeviationEvaluator::callbackNDTPoseWithCovariance(
   if (msg_time - start_time_ > period_) {
     DEBUG_INFO(this->get_logger(), "NDT cycle");
     start_time_ = msg_time;
+    has_published_initial_pose_ = false;
   }
 }
 

--- a/localization/deviation_estimation_tools/deviation_evaluator/src/deviation_evaluator.cpp
+++ b/localization/deviation_estimation_tools/deviation_evaluator/src/deviation_evaluator.cpp
@@ -116,12 +116,12 @@ void DeviationEvaluator::callbackNDTPoseWithCovariance(
   if (!has_published_initial_pose_) {
     geometry_msgs::msg::PoseWithCovarianceStamped pose_with_cov;
     pose_with_cov = *msg;
-    pose_with_cov.pose.covariance[0 * 6 + 0] = 0.01;
-    pose_with_cov.pose.covariance[1 * 6 + 1] = 0.01;
+    pose_with_cov.pose.covariance[0 * 6 + 0] = 0.01 * 0.01;
+    pose_with_cov.pose.covariance[1 * 6 + 1] = 0.01 * 0.01;
     pose_with_cov.pose.covariance[2 * 6 + 2] = 0.01;
     pose_with_cov.pose.covariance[3 * 6 + 3] = 0.01;
     pose_with_cov.pose.covariance[4 * 6 + 4] = 0.01;
-    pose_with_cov.pose.covariance[5 * 6 + 5] = 0.01;
+    pose_with_cov.pose.covariance[5 * 6 + 5] = 0.01 * 0.01;
     pub_init_pose_with_cov_->publish(pose_with_cov);
     has_published_initial_pose_ = true;
     return;

--- a/localization/deviation_estimation_tools/deviation_evaluator/src/deviation_evaluator.cpp
+++ b/localization/deviation_estimation_tools/deviation_evaluator/src/deviation_evaluator.cpp
@@ -118,9 +118,9 @@ void DeviationEvaluator::callbackNDTPoseWithCovariance(
     pose_with_cov = *msg;
     pose_with_cov.pose.covariance[0 * 6 + 0] = 0.01 * 0.01;
     pose_with_cov.pose.covariance[1 * 6 + 1] = 0.01 * 0.01;
-    pose_with_cov.pose.covariance[2 * 6 + 2] = 0.01;
-    pose_with_cov.pose.covariance[3 * 6 + 3] = 0.01;
-    pose_with_cov.pose.covariance[4 * 6 + 4] = 0.01;
+    pose_with_cov.pose.covariance[2 * 6 + 2] = 0.01 * 0.01;
+    pose_with_cov.pose.covariance[3 * 6 + 3] = 0.01 * 0.01;
+    pose_with_cov.pose.covariance[4 * 6 + 4] = 0.01 * 0.01;
     pose_with_cov.pose.covariance[5 * 6 + 5] = 0.01 * 0.01;
     pub_init_pose_with_cov_->publish(pose_with_cov);
     has_published_initial_pose_ = true;


### PR DESCRIPTION
Signed-off-by: kminoda <koji.minoda@tier4.jp>

## Description
Now EKF is initialized every time when the NDT cycle is looped (e.g. every 10[s]).
<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
