### PR TITLE
fix(deviation_evaluator): change default initial pose covariance

### DIFF
--- a/localization/deviation_estimation_tools/deviation_evaluator/src/deviation_evaluator.cpp
+++ b/localization/deviation_estimation_tools/deviation_evaluator/src/deviation_evaluator.cpp
@@ -116,12 +116,12 @@ void DeviationEvaluator::callbackNDTPoseWithCovariance(
   if (!has_published_initial_pose_) {
     geometry_msgs::msg::PoseWithCovarianceStamped pose_with_cov;
     pose_with_cov = *msg;
-    pose_with_cov.pose.covariance[0 * 6 + 0] = 0.01 * 0.01;
-    pose_with_cov.pose.covariance[1 * 6 + 1] = 0.01 * 0.01;
-    pose_with_cov.pose.covariance[2 * 6 + 2] = 0.01 * 0.01;
-    pose_with_cov.pose.covariance[3 * 6 + 3] = 0.01 * 0.01;
-    pose_with_cov.pose.covariance[4 * 6 + 4] = 0.01 * 0.01;
-    pose_with_cov.pose.covariance[5 * 6 + 5] = 0.01 * 0.01;
+    pose_with_cov.pose.covariance[0 * 6 + 0] = 0.03 * 0.03;
+    pose_with_cov.pose.covariance[1 * 6 + 1] = 0.03 * 0.03;
+    pose_with_cov.pose.covariance[2 * 6 + 2] = 0.03 * 0.03;
+    pose_with_cov.pose.covariance[3 * 6 + 3] = 0.03 * 0.03;
+    pose_with_cov.pose.covariance[4 * 6 + 4] = 0.03 * 0.03;
+    pose_with_cov.pose.covariance[5 * 6 + 5] = 0.03 * 0.03;
     pub_init_pose_with_cov_->publish(pose_with_cov);
     has_published_initial_pose_ = true;
     return;


### PR DESCRIPTION
Signed-off-by: kminoda <koji.minoda@tier4.jp>

## Description
Previous initial pose covariance was too small that the deviation_evaluator failed in some cases.

(Errors sometimes overvalued the expected error when the EKF was initialized. The problem was due to the very small expected errors provided from deviation_evaluator)
<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
