### PR TITLE
fix(deviation_evaluator): add localization

### DIFF
--- a/localization/deviation_estimation_tools/deviation_evaluator/src/deviation_evaluator.cpp
+++ b/localization/deviation_estimation_tools/deviation_evaluator/src/deviation_evaluator.cpp
@@ -123,6 +123,7 @@ void DeviationEvaluator::callbackNDTPoseWithCovariance(
     pose_with_cov.pose.covariance[5 * 6 + 5] = initial_angle_stddev * initial_angle_stddev;
     pub_init_pose_with_cov_->publish(pose_with_cov);
     has_published_initial_pose_ = true;
+    start_time_ = rclcpp::Time(msg->header.stamp).seconds();
     return;
   }
 


### PR DESCRIPTION
Signed-off-by: kminoda <koji.minoda@tier4.jp>

## Description
Before: Cut NDT right after deviation_evaluator launches
After: Cut NDT after waiting for `wait_duration` 
<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
