### PR TITLE
fix(extrinsic_mapping_based_calibrator): added a minimum range for lidars

### DIFF
--- a/sensor/extrinsic_mapping_based_calibrator/include/extrinsic_mapping_based_calibrator/sensor_calibrator.hpp
+++ b/sensor/extrinsic_mapping_based_calibrator/include/extrinsic_mapping_based_calibrator/sensor_calibrator.hpp
@@ -66,7 +66,8 @@ protected:
    * @retval Source to distance pointcloud distance
    */
   PointcloudType::Ptr getDensePointcloudFromMap(
-    const Eigen::Matrix4f & pose, const Frame::Ptr & frame, double resolution, double max_range);
+    const Eigen::Matrix4f & pose, const Frame::Ptr & frame, double resolution, double min_range,
+    double max_range);
 
   std::string calibrator_sensor_frame_;
   std::string calibrator_name_;

--- a/sensor/extrinsic_mapping_based_calibrator/include/extrinsic_mapping_based_calibrator/types.hpp
+++ b/sensor/extrinsic_mapping_based_calibrator/include/extrinsic_mapping_based_calibrator/types.hpp
@@ -140,6 +140,7 @@ struct MappingParameters
   bool use_rosbag_;
   int mapping_max_frames_;
   int local_map_num_keyframes_;
+  double mapping_min_range_;
   double mapping_max_range_;
   int min_mapping_pointcloud_size_;
   int min_calibration_pointcloud_size_;

--- a/sensor/extrinsic_mapping_based_calibrator/include/extrinsic_mapping_based_calibrator/types.hpp
+++ b/sensor/extrinsic_mapping_based_calibrator/include/extrinsic_mapping_based_calibrator/types.hpp
@@ -205,6 +205,7 @@ struct CalibrationParameters
 
   bool calibration_use_only_stopped_;
   bool calibration_use_only_last_frames_;
+  double min_calibration_range_;
   double max_calibration_range_;
   double calibration_min_pca_eigenvalue_;
   double calibration_min_distance_between_frames_;

--- a/sensor/extrinsic_mapping_based_calibrator/include/extrinsic_mapping_based_calibrator/utils.hpp
+++ b/sensor/extrinsic_mapping_based_calibrator/include/extrinsic_mapping_based_calibrator/utils.hpp
@@ -48,7 +48,7 @@ void transformPointcloud(
  */
 template <typename PointcloudType>
 typename PointcloudType::Ptr cropPointCloud(
-  const typename PointcloudType::Ptr & pointcloud, double max_range);
+  const typename PointcloudType::Ptr & pointcloud, double min_range, double max_range);
 
 /*!
  * Interpolate a transform between two points in time
@@ -137,6 +137,6 @@ void findBestTransform(
 template <class PointType>
 void cropTargetPointcloud(
   const typename pcl::PointCloud<PointType>::Ptr & initial_source_aligned_pc_ptr,
-  typename pcl::PointCloud<PointType>::Ptr & target_dense_pc_ptr, float margin);
+  typename pcl::PointCloud<PointType>::Ptr & target_dense_pc_ptr, float max_radius);
 
 #endif  // EXTRINSIC_MAPPING_BASED_CALIBRATOR__UTILS_HPP_

--- a/sensor/extrinsic_mapping_based_calibrator/launch/calibrator.launch.xml
+++ b/sensor/extrinsic_mapping_based_calibrator/launch/calibrator.launch.xml
@@ -35,6 +35,7 @@
   <arg name="lost_frame_max_angle_diff" default="25.0"/>
   <arg name="lost_frame_interpolation_error" default="0.05"/>
   <arg name="lost_frame_max_acceleration" default="8.0"/>
+  <arg name="min_calibration_range" default="1.5"/>
   <arg name="max_calibration_range" default="80.0"/>
   <arg name="calibration_min_pca_eigenvalue" default="0.02"/>
   <arg name="calibration_eval_max_corr_distance" default="0.2"/>
@@ -99,6 +100,7 @@
       <param name="lost_frame_max_angle_diff" value="$(var lost_frame_max_angle_diff)"/>
       <param name="lost_frame_interpolation_error" value="$(var lost_frame_interpolation_error)"/>
       <param name="lost_frame_max_acceleration" value="$(var lost_frame_max_acceleration)"/>
+      <param name="min_calibration_range" value="$(var min_calibration_range)"/>
       <param name="max_calibration_range" value="$(var max_calibration_range)"/>
       <param name="calibration_min_pca_eigenvalue" value="$(var calibration_min_pca_eigenvalue)"/>
       <param name="calibration_eval_max_corr_distance" value="$(var calibration_eval_max_corr_distance)"/>

--- a/sensor/extrinsic_mapping_based_calibrator/src/base_lidar_calibrator.cpp
+++ b/sensor/extrinsic_mapping_based_calibrator/src/base_lidar_calibrator.cpp
@@ -64,7 +64,7 @@ bool BaseLidarCalibrator::calibrate(
   auto & last_keyframe = data_->keyframes_and_stopped_.back();
   PointcloudType::Ptr augmented_pointcloud_ptr = getDensePointcloudFromMap(
     last_keyframe->pose_, last_keyframe, parameters_->leaf_size_dense_map_,
-    parameters_->max_calibration_range_);
+    parameters_->min_calibration_range_, parameters_->max_calibration_range_);
 
   Eigen::Matrix4f initial_lidar_to_base_transform;
   Eigen::Isometry3d initial_lidar_to_base_affine;

--- a/sensor/extrinsic_mapping_based_calibrator/src/calibration_mapper.cpp
+++ b/sensor/extrinsic_mapping_based_calibrator/src/calibration_mapper.cpp
@@ -264,8 +264,8 @@ void CalibrationMapper::mappingThreadWorker()
     VoxelGridWrapper<PointType> voxel_grid;
     frame->pointcloud_subsampled_ = PointcloudType::Ptr(new PointcloudType());
     PointcloudType::Ptr aligned_cloud_ptr(new PointcloudType());
-    PointcloudType::Ptr cropped_cloud_ptr =
-      cropPointCloud<PointcloudType>(frame->pointcloud_raw_, 0.0, parameters_->mapping_max_range_);
+    PointcloudType::Ptr cropped_cloud_ptr = cropPointCloud<PointcloudType>(
+      frame->pointcloud_raw_, parameters_->mapping_min_range_, parameters_->mapping_max_range_);
 
     voxel_grid.setLeafSize(
       parameters_->leaf_size_input_, parameters_->leaf_size_input_, parameters_->leaf_size_input_);
@@ -365,8 +365,8 @@ void CalibrationMapper::mappingThreadWorker()
 void CalibrationMapper::initLocalMap(Frame::Ptr frame)
 {
   data_->local_map_ptr_.reset(new PointcloudType());
-  PointcloudType::Ptr cropped_cloud_ptr =
-    cropPointCloud<PointcloudType>(frame->pointcloud_raw_, 0.0, parameters_->mapping_max_range_);
+  PointcloudType::Ptr cropped_cloud_ptr = cropPointCloud<PointcloudType>(
+    frame->pointcloud_raw_, parameters_->mapping_min_range_, parameters_->mapping_max_range_);
   pcl::VoxelGrid<PointType> voxel_grid;
   voxel_grid.setLeafSize(
     parameters_->leaf_size_local_map_, parameters_->leaf_size_local_map_,

--- a/sensor/extrinsic_mapping_based_calibrator/src/calibration_mapper.cpp
+++ b/sensor/extrinsic_mapping_based_calibrator/src/calibration_mapper.cpp
@@ -265,7 +265,7 @@ void CalibrationMapper::mappingThreadWorker()
     frame->pointcloud_subsampled_ = PointcloudType::Ptr(new PointcloudType());
     PointcloudType::Ptr aligned_cloud_ptr(new PointcloudType());
     PointcloudType::Ptr cropped_cloud_ptr =
-      cropPointCloud<PointcloudType>(frame->pointcloud_raw_, parameters_->mapping_max_range_);
+      cropPointCloud<PointcloudType>(frame->pointcloud_raw_, 0.0, parameters_->mapping_max_range_);
 
     voxel_grid.setLeafSize(
       parameters_->leaf_size_input_, parameters_->leaf_size_input_, parameters_->leaf_size_input_);
@@ -366,7 +366,7 @@ void CalibrationMapper::initLocalMap(Frame::Ptr frame)
 {
   data_->local_map_ptr_.reset(new PointcloudType());
   PointcloudType::Ptr cropped_cloud_ptr =
-    cropPointCloud<PointcloudType>(frame->pointcloud_raw_, parameters_->mapping_max_range_);
+    cropPointCloud<PointcloudType>(frame->pointcloud_raw_, 0.0, parameters_->mapping_max_range_);
   pcl::VoxelGrid<PointType> voxel_grid;
   voxel_grid.setLeafSize(
     parameters_->leaf_size_local_map_, parameters_->leaf_size_local_map_,
@@ -617,7 +617,7 @@ void CalibrationMapper::publisherTimerCallback()
 
     pcl::transformPointCloud(
       *tmp_mcs_ptr, *tmp_mcs_ptr, data_->processed_frames_.back()->pose_.inverse());
-    tmp_mcs_ptr = cropPointCloud<PointcloudType>(tmp_mcs_ptr, parameters_->viz_max_range_);
+    tmp_mcs_ptr = cropPointCloud<PointcloudType>(tmp_mcs_ptr, 0.0, parameters_->viz_max_range_);
     pcl::transformPointCloud(*tmp_mcs_ptr, *tmp_mcs_ptr, data_->processed_frames_.back()->pose_);
 
     pcl::VoxelGrid<PointType> voxel_grid;

--- a/sensor/extrinsic_mapping_based_calibrator/src/camera_calibrator.cpp
+++ b/sensor/extrinsic_mapping_based_calibrator/src/camera_calibrator.cpp
@@ -161,7 +161,8 @@ void CameraCalibrator::prepareCalibrationData(
   for (auto & calibration_frame : calibration_frames) {
     PointcloudType::Ptr target_pc_ptr = getDensePointcloudFromMap(
       calibration_frame.local_map_pose_, calibration_frame.target_frame_,
-      parameters_->leaf_size_dense_map_, parameters_->max_calibration_range_ + initial_distance);
+      parameters_->leaf_size_dense_map_, parameters_->min_calibration_range_,
+      parameters_->max_calibration_range_ + initial_distance);
 
     filter.setCameraPose(initial_calibration_transform * adapter_matrix);
     filter.setInputCloud(target_pc_ptr);

--- a/sensor/extrinsic_mapping_based_calibrator/src/extrinsic_mapping_based_calibrator.cpp
+++ b/sensor/extrinsic_mapping_based_calibrator/src/extrinsic_mapping_based_calibrator.cpp
@@ -219,6 +219,8 @@ ExtrinsicMappingBasedCalibrator::ExtrinsicMappingBasedCalibrator(
     this->declare_parameter<bool>("calibration_use_only_last_frames", false);
   calibration_parameters_->max_calibration_range_ =
     this->declare_parameter<double>("max_calibration_range", 80.0);
+  calibration_parameters_->min_calibration_range_ =
+    this->declare_parameter<double>("min_calibration_range", 1.5);
   calibration_parameters_->calibration_min_pca_eigenvalue_ =
     this->declare_parameter<double>("calibration_min_pca_eigenvalue", 0.25);
   calibration_parameters_->calibration_min_distance_between_frames_ =
@@ -542,6 +544,7 @@ rcl_interfaces::msg::SetParametersResult ExtrinsicMappingBasedCalibrator::paramC
     UPDATE_PARAM(mapping_parameters, lost_frame_max_angle_diff);
     UPDATE_PARAM(mapping_parameters, lost_frame_interpolation_error);
     UPDATE_PARAM(mapping_parameters, lost_frame_max_acceleration);
+    UPDATE_PARAM(calibration_parameters, min_calibration_range);
     UPDATE_PARAM(calibration_parameters, max_calibration_range);
     UPDATE_PARAM(calibration_parameters, calibration_min_pca_eigenvalue);
     UPDATE_PARAM(calibration_parameters, calibration_min_distance_between_frames);
@@ -916,7 +919,7 @@ void ExtrinsicMappingBasedCalibrator::saveDatabaseCallback(
   }
 
   PointcloudType::Ptr map_cropped_cloud_ptr =
-    cropPointCloud<PointcloudType>(map_cloud_ptr, mapping_parameters_->mapping_max_range_);
+    cropPointCloud<PointcloudType>(map_cloud_ptr, 0.0, mapping_parameters_->mapping_max_range_);
 
   pcl::VoxelGridTriplets<PointType> voxel_grid;
   voxel_grid.setLeafSize(

--- a/sensor/extrinsic_mapping_based_calibrator/src/extrinsic_mapping_based_calibrator.cpp
+++ b/sensor/extrinsic_mapping_based_calibrator/src/extrinsic_mapping_based_calibrator.cpp
@@ -133,6 +133,8 @@ ExtrinsicMappingBasedCalibrator::ExtrinsicMappingBasedCalibrator(
     this->declare_parameter<int>("local_map_num_keyframes", 15);
   calibration_parameters_->dense_pointcloud_num_keyframes_ =
     this->declare_parameter<int>("dense_pointcloud_num_keyframes", 10);
+  mapping_parameters_->mapping_min_range_ =
+    this->declare_parameter<double>("mapping_min_range", 0.5);
   mapping_parameters_->mapping_max_range_ =
     this->declare_parameter<double>("mapping_max_range", 60.0);
   mapping_parameters_->min_mapping_pointcloud_size_ =
@@ -918,8 +920,9 @@ void ExtrinsicMappingBasedCalibrator::saveDatabaseCallback(
     *map_cloud_ptr += *tmp_cloud_ptr;
   }
 
-  PointcloudType::Ptr map_cropped_cloud_ptr =
-    cropPointCloud<PointcloudType>(map_cloud_ptr, 0.0, mapping_parameters_->mapping_max_range_);
+  PointcloudType::Ptr map_cropped_cloud_ptr = cropPointCloud<PointcloudType>(
+    map_cloud_ptr, mapping_parameters_->mapping_min_range_,
+    mapping_parameters_->mapping_max_range_);
 
   pcl::VoxelGridTriplets<PointType> voxel_grid;
   voxel_grid.setLeafSize(

--- a/sensor/extrinsic_mapping_based_calibrator/src/lidar_calibrator.cpp
+++ b/sensor/extrinsic_mapping_based_calibrator/src/lidar_calibrator.cpp
@@ -163,14 +163,16 @@ void LidarCalibrator::singleSensorCalibrationCallback(
 
   CalibrationFrame & calibration_frame = filtered_calibration_frames[request->id];
   PointcloudType::Ptr source_pc_ptr = cropPointCloud<PointcloudType>(
-    calibration_frame.source_pointcloud_, parameters_->max_calibration_range_);
+    calibration_frame.source_pointcloud_, parameters_->min_calibration_range_,
+    parameters_->max_calibration_range_);
 
   PointcloudType::Ptr target_dense_pc_ptr = getDensePointcloudFromMap(
     calibration_frame.local_map_pose_, calibration_frame.target_frame_,
-    parameters_->leaf_size_dense_map_, parameters_->max_calibration_range_ + initial_distance);
+    parameters_->leaf_size_dense_map_, parameters_->min_calibration_range_,
+    parameters_->max_calibration_range_ + initial_distance);
   PointcloudType::Ptr target_thin_pc_ptr = getDensePointcloudFromMap(
     calibration_frame.local_map_pose_, calibration_frame.target_frame_,
-    parameters_->calibration_viz_leaf_size_,
+    parameters_->calibration_viz_leaf_size_, parameters_->min_calibration_range_,
     parameters_->max_calibration_range_ + initial_distance);
 
   PointcloudType::Ptr initial_source_aligned_pc_ptr(new PointcloudType());
@@ -508,15 +510,17 @@ void LidarCalibrator::prepareCalibrationData(
   // Prepare pointclouds for calibration
   for (auto & calibration_frame : calibration_frames) {
     PointcloudType::Ptr source_pc_ptr = cropPointCloud<PointcloudType>(
-      calibration_frame.source_pointcloud_, parameters_->max_calibration_range_);
+      calibration_frame.source_pointcloud_, parameters_->min_calibration_range_,
+      parameters_->max_calibration_range_);
 
     PointcloudType::Ptr target_pc_ptr = getDensePointcloudFromMap(
       calibration_frame.local_map_pose_, calibration_frame.target_frame_,
-      parameters_->leaf_size_dense_map_, parameters_->max_calibration_range_ + initial_distance);
+      parameters_->leaf_size_dense_map_, parameters_->min_calibration_range_,
+      parameters_->max_calibration_range_ + initial_distance);
 
     PointcloudType::Ptr target_thin_pc_ptr = getDensePointcloudFromMap(
       calibration_frame.local_map_pose_, calibration_frame.target_frame_,
-      parameters_->calibration_viz_leaf_size_,
+      parameters_->calibration_viz_leaf_size_, parameters_->min_calibration_range_,
       parameters_->max_calibration_range_ + initial_distance);
 
     // Transfor the source to target frame to crop it later

--- a/sensor/extrinsic_mapping_based_calibrator/src/utils.cpp
+++ b/sensor/extrinsic_mapping_based_calibrator/src/utils.cpp
@@ -59,12 +59,16 @@ void transformPointcloud(
 
 template <typename PointcloudType>
 typename PointcloudType::Ptr cropPointCloud(
-  const typename PointcloudType::Ptr & pointcloud, double max_range)
+  const typename PointcloudType::Ptr & pointcloud, double min_range, double max_range)
 {
   typename PointcloudType::Ptr tmp_ptr(new PointcloudType());
   tmp_ptr->reserve(pointcloud->size());
+  const float sqr_min_range = min_range * min_range;
+  const float sqr_max_range = max_range * max_range;
   for (const auto & p : pointcloud->points) {
-    if (std::sqrt(p.x * p.x + p.y * p.y + p.z * p.z) < max_range) {
+    const float sqr_r = p.x * p.x + p.y * p.y + p.z * p.z;
+
+    if (sqr_r >= sqr_min_range && sqr_r < sqr_max_range) {
       tmp_ptr->points.push_back(p);
     }
   }
@@ -294,7 +298,7 @@ template float sourceTargetDistance<PointType>(
   const Eigen::Matrix4f & transform, float max_corr_distance);
 
 template PointcloudType::Ptr cropPointCloud<PointcloudType>(
-  const PointcloudType::Ptr & pointcloud, double max_range);
+  const PointcloudType::Ptr & pointcloud, double min_range, double max_range);
 
 template void findBestTransform<pcl::Registration<PointType, PointType>, PointType>(
   const std::vector<Eigen::Matrix4f> & input_transforms,


### PR DESCRIPTION

## Description
Some of our lidars presents innacurate readings at close distances, which affect the calibration process.
As a partial measure, we decided to just ignore this data.

<!-- Write a brief description of this PR. -->

## Related links
[TIER IV INTERNAL LINK](https://tier4.atlassian.net/wiki/spaces/CT/pages/2792686054/SP+2023-06-01+HESAI+40P+QT+pointcloud+quality+issues)
<!-- Write the links related to this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
