### PR TITLE
fix(extrinsic_interactive_calibrator): "lidar_frame" initiatlization

### DIFF
--- a/sensor/extrinsic_interactive_calibrator/extrinsic_interactive_calibrator/ros_interface.py
+++ b/sensor/extrinsic_interactive_calibrator/extrinsic_interactive_calibrator/ros_interface.py
@@ -85,6 +85,7 @@ class RosInterface(Node):
         self.can_publish_tf = self.get_parameter("can_publish_tf").get_parameter_value().bool_value
 
         self.image_frame = None
+        self.lidar_frame = None
 
         self.ros_context = None
         self.ros_executor = None


### PR DESCRIPTION
## Description

The `lidar_frame` variable in `extrinsic_interactive_calibrator/ros_interface.py` is not initialized.
Depending on the state of the sensor topics, this problem may cause this node to fail.

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
