### PR TITLE
fix(lidar-lidar-calib): fix crash when passing point cloud with zero points

### DIFF
--- a/sensor/extrinsic_calibration_client/src/extrinsic_calibration_client.cpp
+++ b/sensor/extrinsic_calibration_client/src/extrinsic_calibration_client.cpp
@@ -42,9 +42,10 @@ int main(int argc, char * argv[])
     std::make_shared<tier4_calibration_msgs::srv::ExtrinsicCalibrationManager::Request>();
   request->src_path = node->declare_parameter("src_path", "");
   request->dst_path = node->declare_parameter("dst_path", "");
-  auto result = client->async_send_request(request);
+  auto future = client->async_send_request(request);
 
-  if (rclcpp::spin_until_future_complete(node, result) == rclcpp::FutureReturnCode::SUCCESS) {
+  if (rclcpp::spin_until_future_complete(node, future) == rclcpp::FutureReturnCode::SUCCESS) {
+    auto result = future.get();
     RCLCPP_INFO_STREAM(
       node->get_logger(),
       "Received service message. success " << result.get()->success << " score " <<

--- a/sensor/extrinsic_calibration_manager/src/extrinsic_calibration_manager_node.cpp
+++ b/sensor/extrinsic_calibration_manager/src/extrinsic_calibration_manager_node.cpp
@@ -88,13 +88,13 @@ void ExtrinsicCalibrationManagerNode::calibrationRequestCallback(
         target_client.response = *res;
         target_client.estimated = true;
         if(res->success){
-        RCLCPP_INFO_STREAM(
-          this->get_logger(), "Received service message: " << target_client.child_frame <<
+          RCLCPP_INFO_STREAM(
+            this->get_logger(), "Received service message: " << target_client.child_frame <<
             "(success = " << res->success <<
             " score = " << res->score << ")");
         }else{
-        RCLCPP_ERROR_STREAM(
-          this->get_logger(), "calibration_failed: " << target_client.child_frame);
+          RCLCPP_ERROR_STREAM(
+            this->get_logger(), "calibration_failed: " << target_client.child_frame);
         }
       };
 

--- a/sensor/extrinsic_calibration_manager/src/extrinsic_calibration_manager_node.cpp
+++ b/sensor/extrinsic_calibration_manager/src/extrinsic_calibration_manager_node.cpp
@@ -87,10 +87,15 @@ void ExtrinsicCalibrationManagerNode::calibrationRequestCallback(
         auto res = response_client.get();
         target_client.response = *res;
         target_client.estimated = true;
+        if(res->success){
         RCLCPP_INFO_STREAM(
           this->get_logger(), "Received service message: " << target_client.child_frame <<
             "(success = " << res->success <<
             " score = " << res->score << ")");
+        }else{
+        RCLCPP_ERROR_STREAM(
+          this->get_logger(), "calibration_failed: " << target_client.child_frame);
+        }
       };
 
     RCLCPP_INFO_STREAM(this->get_logger(), "Call service: " << target_client.child_frame);

--- a/sensor/extrinsic_map_based_calibrator/src/extrinsic_map_based_calibrator.cpp
+++ b/sensor/extrinsic_map_based_calibrator/src/extrinsic_map_based_calibrator.cpp
@@ -171,12 +171,16 @@ bool ExtrinsicMapBasedCalibrator::mapBasedCalibration(const tf2::Transform & tf_
     if (!preprocessing(pcl_map, pcl_map_without_wall, pcl_sensor, tf_initial_pose)) {
       return false;
     }
-    grid_search_matching_.executeGridSearchMatching(pcl_map_without_wall, pcl_sensor);
+    if(grid_search_matching_.executeGridSearchMatching(pcl_map_without_wall, pcl_sensor)){
+      return false;
+    }
   } else {
     if (!preprocessing(pcl_map, pcl_sensor, tf_initial_pose)) {
       return false;
     }
-    grid_search_matching_.executeGridSearchMatching(pcl_map, pcl_sensor);
+    if(grid_search_matching_.executeGridSearchMatching(pcl_map, pcl_sensor)){
+      return false;
+    }
   }
 
   calibrated_sensor_result_ = grid_search_matching_.getRematchedResult();

--- a/sensor/extrinsic_map_based_calibrator/src/extrinsic_map_based_calibrator.cpp
+++ b/sensor/extrinsic_map_based_calibrator/src/extrinsic_map_based_calibrator.cpp
@@ -171,14 +171,14 @@ bool ExtrinsicMapBasedCalibrator::mapBasedCalibration(const tf2::Transform & tf_
     if (!preprocessing(pcl_map, pcl_map_without_wall, pcl_sensor, tf_initial_pose)) {
       return false;
     }
-    if(grid_search_matching_.executeGridSearchMatching(pcl_map_without_wall, pcl_sensor)){
+    if(!grid_search_matching_.executeGridSearchMatching(pcl_map_without_wall, pcl_sensor)){
       return false;
     }
   } else {
     if (!preprocessing(pcl_map, pcl_sensor, tf_initial_pose)) {
       return false;
     }
-    if(grid_search_matching_.executeGridSearchMatching(pcl_map, pcl_sensor)){
+    if(!grid_search_matching_.executeGridSearchMatching(pcl_map, pcl_sensor)){
       return false;
     }
   }

--- a/sensor/extrinsic_map_based_calibrator/src/extrinsic_map_based_calibrator.cpp
+++ b/sensor/extrinsic_map_based_calibrator/src/extrinsic_map_based_calibrator.cpp
@@ -141,7 +141,7 @@ bool ExtrinsicMapBasedCalibrator::mapBasedCalibration(const tf2::Transform & tf_
     return false;
   }
   if (!sensor_pointcloud_msg_) {
-    RCLCPP_ERROR(this->get_logger(), "Can not received pandar left upper point cloud topic");
+    RCLCPP_ERROR(this->get_logger(), "Can not received sensor point cloud topic");
     return false;
   }
 
@@ -156,11 +156,11 @@ bool ExtrinsicMapBasedCalibrator::mapBasedCalibration(const tf2::Transform & tf_
     }
   }
   if (sensor_pointcloud_msg_->height == 0) {
-    RCLCPP_ERROR(this->get_logger(), "Can not received pandar left upper point cloud topic height = 0");
+    RCLCPP_ERROR(this->get_logger(), "Can not received sensor point cloud topic height = 0");
     return false;
   }
   if (sensor_pointcloud_msg_->width == 0) {
-    RCLCPP_ERROR(this->get_logger(), "Can not received pandar left upper point cloud topic width = 0");
+    RCLCPP_ERROR(this->get_logger(), "Can not received sensor point cloud topic width = 0");
     return false;
   }
 

--- a/sensor/extrinsic_map_based_calibrator/src/extrinsic_map_based_calibrator.cpp
+++ b/sensor/extrinsic_map_based_calibrator/src/extrinsic_map_based_calibrator.cpp
@@ -156,7 +156,11 @@ bool ExtrinsicMapBasedCalibrator::mapBasedCalibration(const tf2::Transform & tf_
     }
   }
   if (sensor_pointcloud_msg_->height == 0) {
-    RCLCPP_ERROR(this->get_logger(), "Can not received pandar left upper point cloud topic");
+    RCLCPP_ERROR(this->get_logger(), "Can not received pandar left upper point cloud topic height = 0");
+    return false;
+  }
+  if (sensor_pointcloud_msg_->width == 0) {
+    RCLCPP_ERROR(this->get_logger(), "Can not received pandar left upper point cloud topic width = 0");
     return false;
   }
 

--- a/sensor/extrinsic_map_based_calibrator/src/extrinsic_map_based_preprocessing.cpp
+++ b/sensor/extrinsic_map_based_calibrator/src/extrinsic_map_based_preprocessing.cpp
@@ -90,6 +90,9 @@ bool ExtrinsicMapBasedPreprocessing::extractGroundPlane(
 
   // Obtain an idea of the ground plane using PCA
   // under the asumption that the axis with less variance will be the ground plane normal
+  if(pointcloud->size() < 3){
+    return false;
+  }
   pcl::PCA<pcl::PointXYZ> pca;
   pca.setInputCloud(pointcloud);
   Eigen::MatrixXf vectors = pca.getEigenVectors();

--- a/sensor/extrinsic_map_based_calibrator/src/grid_search_matching.cpp
+++ b/sensor/extrinsic_map_based_calibrator/src/grid_search_matching.cpp
@@ -24,10 +24,10 @@ GridSearchMatching::GridSearchMatching() {}
 bool GridSearchMatching::executeGridSearchMatching(
   const PointCloudT::Ptr & map_pointcloud, const PointCloudT::Ptr & sensor_pointcloud)
 {
-  if (map_pointcloud == 0 || map_pointcloud->height == 0) {
+  if (map_pointcloud == 0 || map_pointcloud->height == 0|| map_pointcloud->width == 0) {
     std::cerr << "Map point cloud is empty" << std::endl;
     return false;
-  } else if (sensor_pointcloud == 0 || sensor_pointcloud->height == 0) {
+  } else if (sensor_pointcloud == 0 || sensor_pointcloud->height == 0||sensor_pointcloud->width == 0) {
     std::cerr << "Sensor point cloud is empty" << std::endl;
     return false;
   }


### PR DESCRIPTION
## Description
Fixed bugs that occurred when the version of ros2 was upgraded to humble.
- Fix issue causing crash when passing point cloud with zero points to PCL's transformPointCloud
  - I have added the task of displaying the service status of each sensor frame in the terminal.
- Fix service client crash by updating humble
- Fix a problem the number of point clouds is less than 3 when calculating pca
## Related links
https://tier4.atlassian.net/browse/AEAP-546

## Tests performed
- Try inputting a zero point cloud and confirm that no calibration nodes have fallen.
- Using rosbag, I confirmed that calibration result is equivalent to previous version.
![image](https://github.com/tier4/CalibrationTools/assets/54956813/6fe55efc-fe59-47d2-a26a-10b46802c81a)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
