### PR TITLE
fix(deviation_evaluator): add depend package autoware_cmake

### DIFF
--- a/localization/deviation_estimation_tools/deviation_evaluator/CMakeLists.txt
+++ b/localization/deviation_estimation_tools/deviation_evaluator/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.5)
 project(deviation_evaluator)
 
+find_package(autoware_cmake REQUIRED)
+autoware_package()
+
 ### Compile options
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)

--- a/localization/deviation_estimation_tools/deviation_evaluator/package.xml
+++ b/localization/deviation_estimation_tools/deviation_evaluator/package.xml
@@ -8,6 +8,7 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <build_depend>autoware_cmake</build_depend>
 
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>


### PR DESCRIPTION
## Description

In the ROS2 galatic environment, the following error occurs during build

```
-- stderr: deviation_evaluator                               
In file included from /home/yamato/pilot-auto.x2/src/vendor/CalibrationTools/localization/deviation_estimation_tools/deviation_evaluator/include/deviation_evaluator/tier4_autoware_utils.hpp:18,
                 from /home/yamato/pilot-auto.x2/src/vendor/CalibrationTools/localization/deviation_estimation_tools/deviation_evaluator/include/deviation_evaluator/deviation_evaluator.hpp:18,
                 from /home/yamato/pilot-auto.x2/src/vendor/CalibrationTools/localization/deviation_estimation_tools/deviation_evaluator/src/deviation_evaluator.cpp:15:
/home/yamato/pilot-auto.x2/install/tier4_autoware_utils/include/tier4_autoware_utils/geometry/geometry.hpp:47:10: fatal error: tf2_geometry_msgs/tf2_geometry_msgs.hpp: そのようなファイルやディレクトリはありません
   47 | #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
In file included from /home/yamato/pilot-auto.x2/src/vendor/CalibrationTools/localization/deviation_estimation_tools/deviation_evaluator/include/deviation_evaluator/tier4_autoware_utils.hpp:18,
                 from /home/yamato/pilot-auto.x2/src/vendor/CalibrationTools/localization/deviation_estimation_tools/deviation_evaluator/include/deviation_evaluator/deviation_evaluator.hpp:18,
                 from /home/yamato/pilot-auto.x2/src/vendor/CalibrationTools/localization/deviation_estimation_tools/deviation_evaluator/src/deviation_evaluator_node.cpp:15:
/home/yamato/pilot-auto.x2/install/tier4_autoware_utils/include/tier4_autoware_utils/geometry/geometry.hpp:47:10: fatal error: tf2_geometry_msgs/tf2_geometry_msgs.hpp: そのようなファイルやディレクトリはありません
   47 | #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
make[2]: *** [CMakeFiles/deviation_evaluator.dir/build.make:76: CMakeFiles/deviation_evaluator.dir/src/deviation_evaluator.cpp.o] エラー 1
make[2]: *** 未完了のジョブを待っています....
make[2]: *** [CMakeFiles/deviation_evaluator.dir/build.make:63: CMakeFiles/deviation_evaluator.dir/src/deviation_evaluator_node.cpp.o] エラー 1
make[1]: *** [CMakeFiles/Makefile2:78: CMakeFiles/deviation_evaluator.dir/all] エラー 2
make: *** [Makefile:141: all] エラー 2
---
Failed   <<< deviation_evaluator [2.54s, exited with code 2]
```
FYI
https://github.com/autowarefoundation/autoware.universe/blob/main/common/tier4_autoware_utils/include/tier4_autoware_utils/geometry/geometry.hpp#L44-L48

I think perhaps the `ROS_DISTRO_GALACTIC` environment variable is not set unless autoware_cmake is specified.

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
