### PR TITLE
fix(extrinsic_calibration_manager): fix tf name

### DIFF
--- a/sensor/extrinsic_calibration_manager/launch/aip_xx1/manual_sensor_kit.launch.xml
+++ b/sensor/extrinsic_calibration_manager/launch/aip_xx1/manual_sensor_kit.launch.xml
@@ -26,8 +26,7 @@
     camera3/camera_link,
     camera4/camera_link,
     camera5/camera_link,
-    traffic_light_right_camera/camera_link,
-    traffic_light_left_camera/camera_link,
+    camera6/camera_link,
     velodyne_top_base_link,
     velodyne_left_base_link,
     velodyne_right_base_link,
@@ -75,15 +74,9 @@
   </include>
 
   <include file="$(find-pkg-share extrinsic_manual_calibrator)/launch/calibrator.launch.xml">
-    <arg name="ns" value="$(var parent_frame)/traffic_light_right_camera/camera_link"/>
+    <arg name="ns" value="$(var parent_frame)/camera6/camera_link"/>
     <arg name="parent_frame" value="$(var parent_frame)"/>
-    <arg name="child_frame" value="traffic_light_right_camera/camera_link"/>
-  </include>
-
-  <include file="$(find-pkg-share extrinsic_manual_calibrator)/launch/calibrator.launch.xml">
-    <arg name="ns" value="$(var parent_frame)/traffic_light_left_camera/camera_link"/>
-    <arg name="parent_frame" value="$(var parent_frame)"/>
-    <arg name="child_frame" value="traffic_light_left_camera/camera_link"/>
+    <arg name="child_frame" value="camera6/camera_link"/>
   </include>
 
   <include file="$(find-pkg-share extrinsic_manual_calibrator)/launch/calibrator.launch.xml">


### PR DESCRIPTION
## Description
Currently, the extrinsic_calibration_manager node dies due to being passed an invalid frame_id.
This causes a issue that the initial values of ```tf_broad_caster``` become all 0. I fixed it.

Before:
![image](https://github.com/tier4/CalibrationTools/assets/59680180/f7a5c760-5bd6-4447-b75c-5debc3589066)


After:
![image](https://github.com/tier4/CalibrationTools/assets/59680180/d8282a04-7270-449e-86ca-ec033bb51746)

<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
