### PR TITLE
fix(ansible): changed git to https to avoid key issues

### DIFF
--- a/calibration_tools.repos
+++ b/calibration_tools.repos
@@ -1,27 +1,27 @@
 repositories:
   autoware/calibration_tools:
     type: git
-    url: git@github.com:tier4/CalibrationTools.git
+    url: https://github.com:tier4/CalibrationTools.git
     version: tier4/universe
   vendor/lidartag:
     type: git
-    url: git@github.com:tier4/LiDARTag.git
+    url: https://github.com:tier4/LiDARTag.git
     version: humble
   vendor/lidartag_msgs:
     type: git
-    url: git@github.com:tier4/LiDARTag_msgs.git
+    url: https://github.com:tier4/LiDARTag_msgs.git
     version: tier4/universe
   vendor/apriltag_msgs:
     type: git
-    url: git@github.com:christianrauch/apriltag_msgs.git
+    url: https://github.com:christianrauch/apriltag_msgs.git
     version: 2.0.0
   vendor/apriltag_ros:
     type: git
-    url: git@github.com:christianrauch/apriltag_ros.git
+    url: https://github.com:christianrauch/apriltag_ros.git
     version: e814e9e5d5f1bfb60a4aa685d30977c632bbc540
   vendor/ros2_numpy:
     type: git
-    url: git@github.com:Box-Robotics/ros2_numpy.git
+    url: https://github.com:Box-Robotics/ros2_numpy.git
     version: humble
   vendor/image_pipeline:
     type: git

--- a/calibration_tools.repos
+++ b/calibration_tools.repos
@@ -1,27 +1,27 @@
 repositories:
   autoware/calibration_tools:
     type: git
-    url: https://github.com:tier4/CalibrationTools.git
+    url: https://github.com/tier4/CalibrationTools.git
     version: tier4/universe
   vendor/lidartag:
     type: git
-    url: https://github.com:tier4/LiDARTag.git
+    url: https://github.com/tier4/LiDARTag.git
     version: humble
   vendor/lidartag_msgs:
     type: git
-    url: https://github.com:tier4/LiDARTag_msgs.git
+    url: https://github.com/tier4/LiDARTag_msgs.git
     version: tier4/universe
   vendor/apriltag_msgs:
     type: git
-    url: https://github.com:christianrauch/apriltag_msgs.git
+    url: https://github.com/christianrauch/apriltag_msgs.git
     version: 2.0.0
   vendor/apriltag_ros:
     type: git
-    url: https://github.com:christianrauch/apriltag_ros.git
+    url: https://github.com/christianrauch/apriltag_ros.git
     version: e814e9e5d5f1bfb60a4aa685d30977c632bbc540
   vendor/ros2_numpy:
     type: git
-    url: https://github.com:Box-Robotics/ros2_numpy.git
+    url: https://github.com/Box-Robotics/ros2_numpy.git
     version: humble
   vendor/image_pipeline:
     type: git


### PR DESCRIPTION
## Description

As reported in https://github.com/tier4/CalibrationTools/issues/116, some users have issues when installing the dependencies. This PR changed the urls from git to https to avoid key issues
<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. -->

## Tests performed
Used the new repos file to check if the dependencies can get installed correctly
<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
