### PR TITLE
feat(deviation_estimator): use yaw stddev instead of max for stddev gyro

### DIFF
--- a/localization/deviation_estimation_tools/deviation_estimator/src/deviation_estimator.cpp
+++ b/localization/deviation_estimation_tools/deviation_estimator/src/deviation_estimator.cpp
@@ -316,10 +316,12 @@ void DeviationEstimator::timer_callback()
   stddev_vx_msg.data = stddev_vx;
   pub_stddev_vx_->publish(stddev_vx_msg);
 
-  // For IMU link standard deviation, we use the minimum value from the calculated standard deviation in base_link.
-  // This is because the standard deviation estimation of x and y in base_link may not be accurate especially when
-  // the data contains a motion when the people are getting on/off the vehicle, which causes the vehicle to tilt in roll and pitch.
-  // In this case, we would like to use the standard deviation of yaw axis in base_link, which is often the smallest value among the three axes.
+  // For IMU link standard deviation, we use the minimum value from the calculated standard
+  // deviation in base_link. This is because the standard deviation estimation of x and y in
+  // base_link may not be accurate especially when the data contains a motion when the people are
+  // getting on/off the vehicle, which causes the vehicle to tilt in roll and pitch. In this case,
+  // we would like to use the standard deviation of yaw axis in base_link, which is often the
+  // smallest value among the three axes.
   double stddev_angvel_imu = std::numeric_limits<double>::max();
   stddev_angvel_imu = std::min(stddev_angvel_imu, stddev_angvel_base.x);
   stddev_angvel_imu = std::min(stddev_angvel_imu, stddev_angvel_base.y);

--- a/localization/deviation_estimation_tools/deviation_estimator/src/deviation_estimator.cpp
+++ b/localization/deviation_estimation_tools/deviation_estimator/src/deviation_estimator.cpp
@@ -316,10 +316,14 @@ void DeviationEstimator::timer_callback()
   stddev_vx_msg.data = stddev_vx;
   pub_stddev_vx_->publish(stddev_vx_msg);
 
-  double stddev_angvel_imu = 0.0;
-  stddev_angvel_imu = std::max(stddev_angvel_imu, stddev_angvel_base.x);
-  stddev_angvel_imu = std::max(stddev_angvel_imu, stddev_angvel_base.y);
-  stddev_angvel_imu = std::max(stddev_angvel_imu, stddev_angvel_base.z);
+  // For IMU link standard deviation, we use the minimum value from the calculated standard deviation in base_link.
+  // This is because the standard deviation estimation of x and y in base_link may not be accurate especially when
+  // the data contains a motion when the people are getting on/off the vehicle, which causes the vehicle to tilt in roll and pitch.
+  // In this case, we would like to use the standard deviation of yaw axis in base_link, which is often the smallest value among the three axes.
+  double stddev_angvel_imu = std::numeric_limits<double>::max();
+  stddev_angvel_imu = std::min(stddev_angvel_imu, stddev_angvel_base.x);
+  stddev_angvel_imu = std::min(stddev_angvel_imu, stddev_angvel_base.y);
+  stddev_angvel_imu = std::min(stddev_angvel_imu, stddev_angvel_base.z);
   geometry_msgs::msg::Vector3 stddev_angvel_imu_msg =
     createVector3(stddev_angvel_imu, stddev_angvel_imu, stddev_angvel_imu);
   pub_stddev_angvel_->publish(stddev_angvel_imu_msg);

--- a/localization/deviation_estimation_tools/deviation_estimator/src/deviation_estimator.cpp
+++ b/localization/deviation_estimation_tools/deviation_estimator/src/deviation_estimator.cpp
@@ -317,9 +317,10 @@ void DeviationEstimator::timer_callback()
   pub_stddev_vx_->publish(stddev_vx_msg);
 
   // For IMU link standard deviation, we use the yaw standard deviation in base_link.
-  // This is because the standard deviation estimation of x and y in base_link may not be accurate especially when
-  // the data contains a motion when the people are getting on/off the vehicle, which causes the vehicle to tilt in roll and pitch.
-  // In this case, we would like to use the standard deviation of yaw axis in base_link.
+  // This is because the standard deviation estimation of x and y in base_link may not be accurate
+  // especially when the data contains a motion when the people are getting on/off the vehicle,
+  // which causes the vehicle to tilt in roll and pitch. In this case, we would like to use the
+  // standard deviation of yaw axis in base_link.
   double stddev_angvel_imu = stddev_angvel_base.z;
   geometry_msgs::msg::Vector3 stddev_angvel_imu_msg =
     createVector3(stddev_angvel_imu, stddev_angvel_imu, stddev_angvel_imu);

--- a/localization/deviation_estimation_tools/deviation_estimator/src/deviation_estimator.cpp
+++ b/localization/deviation_estimation_tools/deviation_estimator/src/deviation_estimator.cpp
@@ -316,16 +316,11 @@ void DeviationEstimator::timer_callback()
   stddev_vx_msg.data = stddev_vx;
   pub_stddev_vx_->publish(stddev_vx_msg);
 
-  // For IMU link standard deviation, we use the minimum value from the calculated standard
-  // deviation in base_link. This is because the standard deviation estimation of x and y in
-  // base_link may not be accurate especially when the data contains a motion when the people are
-  // getting on/off the vehicle, which causes the vehicle to tilt in roll and pitch. In this case,
-  // we would like to use the standard deviation of yaw axis in base_link, which is often the
-  // smallest value among the three axes.
-  double stddev_angvel_imu = std::numeric_limits<double>::max();
-  stddev_angvel_imu = std::min(stddev_angvel_imu, stddev_angvel_base.x);
-  stddev_angvel_imu = std::min(stddev_angvel_imu, stddev_angvel_base.y);
-  stddev_angvel_imu = std::min(stddev_angvel_imu, stddev_angvel_base.z);
+  // For IMU link standard deviation, we use the yaw standard deviation in base_link.
+  // This is because the standard deviation estimation of x and y in base_link may not be accurate especially when
+  // the data contains a motion when the people are getting on/off the vehicle, which causes the vehicle to tilt in roll and pitch.
+  // In this case, we would like to use the standard deviation of yaw axis in base_link.
+  double stddev_angvel_imu = stddev_angvel_base.z;
   geometry_msgs::msg::Vector3 stddev_angvel_imu_msg =
     createVector3(stddev_angvel_imu, stddev_angvel_imu, stddev_angvel_imu);
   pub_stddev_angvel_->publish(stddev_angvel_imu_msg);


### PR DESCRIPTION
## Description

For IMU link standard deviation, we would like to use yaw standard deviation in base_link for all the three axes.

This is because the standard deviation estimation of x and y in base_link may not be accurate especially when the data contains a motion when the people are getting on/off the vehicle, which causes the vehicle to tilt in roll and pitch. In this case, we would like to use the standard deviation of yaw axis in base_link.

For instance, the original algorithm caused a very large standard deviation for stddev_angular_*, e.g. 0.9[rad/s], possible due to the tilting motion of the vehicle when the vehicle is stopped.
With this PR, the estimated value is now around 0.006 [rad/s] for the same rosbag, which is closer to it's real standard deviation apparently from the plot.
<!-- Write a brief description of this PR. -->

## Related links

None
<!-- Write the links related to this PR. -->

## Tests performed

Tested on our calibration data.
<!-- Describe how you have tested this PR. -->

## Notes for reviewers

None
<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
