### PR TITLE
fix(extrinsic_calibration_manager): rename mapping pointcloud topic for xx1

### DIFF
--- a/sensor/extrinsic_calibration_manager/launch/aip_xx1/mapping_based.launch.xml
+++ b/sensor/extrinsic_calibration_manager/launch/aip_xx1/mapping_based.launch.xml
@@ -75,7 +75,7 @@
     velodyne_rear]"/>
 
   <let name="mapping_lidar_frame" value="velodyne_top"/>
-  <let name="mapping_pointcloud" value="/sensing/lidar/top/outlier_filtered/pointcloud"/>
+  <let name="mapping_pointcloud" value="/sensing/lidar/top/pointcloud"/>
   <!--let name="predicted_objects" value="/perception/object_recognition/objects" /-->
   <let name="detected_objects" value="/perception/object_recognition/detection/objects"/>
 

--- a/sensor/extrinsic_calibration_manager/launch/aip_xx1/mapping_based.launch.xml
+++ b/sensor/extrinsic_calibration_manager/launch/aip_xx1/mapping_based.launch.xml
@@ -103,13 +103,10 @@
     /sensing/camera/traffic_light/image_rect_color/compressed]"
   />
 
-  <let
-    name="calibration_pointcloud_topics"
-    value="[
+  <let name="calibration_pointcloud_topics" value="[
     /sensing/lidar/left/pointcloud,
     /sensing/lidar/right/pointcloud,
-    /sensing/lidar/rear/pointcloud]"
-  />
+    /sensing/lidar/rear/pointcloud]"/>
 
   <arg name="rviz"/>
   <let name="rviz_profile" value="$(find-pkg-share extrinsic_mapping_based_calibrator)/rviz/xx1.rviz"/>

--- a/sensor/extrinsic_calibration_manager/launch/aip_xx1/mapping_based.launch.xml
+++ b/sensor/extrinsic_calibration_manager/launch/aip_xx1/mapping_based.launch.xml
@@ -106,9 +106,9 @@
   <let
     name="calibration_pointcloud_topics"
     value="[
-    /sensing/lidar/left/outlier_filtered/pointcloud,
-    /sensing/lidar/right/outlier_filtered/pointcloud,
-    /sensing/lidar/rear/outlier_filtered/pointcloud]"
+    /sensing/lidar/left/pointcloud,
+    /sensing/lidar/right/pointcloud,
+    /sensing/lidar/rear/pointcloud]"
   />
 
   <arg name="rviz"/>


### PR DESCRIPTION
## Description

Rename mapping pointcloud topic for xx1

## Related links

None

## Tests performed

Launched extrinsic mapping-based calibration and confirmed that mapping and calibration has been successfull.

## Notes for reviewers

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
