### PR TITLE
feat: change autoware_auto_msgs to autoware_msgs

### DIFF
--- a/build_depends.repos
+++ b/build_depends.repos
@@ -11,10 +11,6 @@ repositories:
     type: git
     url: https://github.com/tier4/tier4_autoware_msgs.git
     version: tier4/universe
-  autoware/auto_msgs:
-    type: git
-    url: https://github.com/tier4/autoware_auto_msgs.git
-    version: tier4/main
   missing_packages/astuff_sensor_msgs:
     type: git
     url: https://github.com/astuff/astuff_sensor_msgs.git

--- a/sensor/docs/how_to_extrinsic_interactive.md
+++ b/sensor/docs/how_to_extrinsic_interactive.md
@@ -23,7 +23,7 @@ Duration:          51.59s
 Start:             Feb  7 2022 14:23:32.345 (1644211412.345)
 End:               Feb  7 2022 14:24:23.404 (1644211463.404)
 Messages:          252554
-Topic information: Topic: /awapi/autoware/put/engage | Type: autoware_auto_vehicle_msgs/msg/Engage | Count: 0 | Serialization Format: cdr
+Topic information: Topic: /awapi/autoware/put/engage | Type: autoware_vehicle_msgs/msg/Engage | Count: 0 | Serialization Format: cdr
                    Topic: /sensing/camera/camera1/camera_info | Type: sensor_msgs/msg/CameraInfo | Count: 489 | Serialization Format: cdr
                    Topic: /sensing/camera/camera1/trigger_time | Type: builtin_interfaces/msg/Time | Count: 497 | Serialization Format: cdr
                    Topic: /sensing/camera/camera6/camera_info | Type: sensor_msgs/msg/CameraInfo | Count: 463 | Serialization Format: cdr

--- a/sensor/docs/how_to_extrinsic_tag_based.md
+++ b/sensor/docs/how_to_extrinsic_tag_based.md
@@ -48,7 +48,7 @@ Duration:          51.59s
 Start:             Feb  7 2022 14:23:32.345 (1644211412.345)
 End:               Feb  7 2022 14:24:23.404 (1644211463.404)
 Messages:          252554
-Topic information: Topic: /awapi/autoware/put/engage | Type: autoware_auto_vehicle_msgs/msg/Engage | Count: 0 | Serialization Format: cdr
+Topic information: Topic: /awapi/autoware/put/engage | Type: autoware_vehicle_msgs/msg/Engage | Count: 0 | Serialization Format: cdr
                    Topic: /sensing/camera/camera1/camera_info | Type: sensor_msgs/msg/CameraInfo | Count: 489 | Serialization Format: cdr
                    Topic: /sensing/camera/camera1/trigger_time | Type: builtin_interfaces/msg/Time | Count: 497 | Serialization Format: cdr
                    Topic: /sensing/camera/camera6/camera_info | Type: sensor_msgs/msg/CameraInfo | Count: 463 | Serialization Format: cdr

--- a/sensor/mapping_based_calibrator/include/mapping_based_calibrator/mapping_based_calibrator.hpp
+++ b/sensor/mapping_based_calibrator/include/mapping_based_calibrator/mapping_based_calibrator.hpp
@@ -26,8 +26,8 @@
 #include <rclcpp/timer.hpp>
 #include <std_srvs/srv/empty.hpp>
 
-#include <autoware_auto_perception_msgs/msg/detected_objects.hpp>
-#include <autoware_auto_perception_msgs/msg/predicted_objects.hpp>
+#include <autoware_perception_msgs/msg/detected_objects.hpp>
+#include <autoware_perception_msgs/msg/predicted_objects.hpp>
 #include <sensor_msgs/msg/camera_info.hpp>
 #include <sensor_msgs/msg/compressed_image.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
@@ -75,14 +75,14 @@ protected:
    * @param[in] objects Calibration pointcloud msg
    */
   void detectedObjectsCallback(
-    const autoware_auto_perception_msgs::msg::DetectedObjects::SharedPtr objects);
+    const autoware_perception_msgs::msg::DetectedObjects::SharedPtr objects);
 
   /*!
    * Message callback for detected objects
    * @param[in] objects Calibration pointcloud msg
    */
   void predictedObjectsCallback(
-    const autoware_auto_perception_msgs::msg::PredictedObjects::SharedPtr objects);
+    const autoware_perception_msgs::msg::PredictedObjects::SharedPtr objects);
 
   /*!
    * Callback to set parameters using the ROS interface
@@ -111,9 +111,9 @@ protected:
   std::map<std::string, ImageSubscription::SharedPtr> calibration_image_subs_;
   std::map<std::string, PointSubscription::SharedPtr> calibration_pointcloud_subs_;
   PointSubscription::SharedPtr mapping_pointcloud_sub_;
-  rclcpp::Subscription<autoware_auto_perception_msgs::msg::DetectedObjects>::SharedPtr
+  rclcpp::Subscription<autoware_perception_msgs::msg::DetectedObjects>::SharedPtr
     detected_objects_sub_;
-  rclcpp::Subscription<autoware_auto_perception_msgs::msg::PredictedObjects>::SharedPtr
+  rclcpp::Subscription<autoware_perception_msgs::msg::PredictedObjects>::SharedPtr
     predicted_objects_sub_;
 
   rclcpp::Service<tier4_calibration_msgs::srv::ExtrinsicCalibrator>::SharedPtr service_server_;

--- a/sensor/mapping_based_calibrator/package.xml
+++ b/sensor/mapping_based_calibrator/package.xml
@@ -12,7 +12,7 @@
 
   <build_depend>autoware_cmake</build_depend>
 
-  <depend>autoware_auto_perception_msgs</depend>
+  <depend>autoware_perception_msgs</depend>
   <depend>eigen</depend>
   <depend>geometry_msgs</depend>
   <depend>image_geometry</depend>

--- a/sensor/mapping_based_calibrator/src/mapping_based_calibrator.cpp
+++ b/sensor/mapping_based_calibrator/src/mapping_based_calibrator.cpp
@@ -377,11 +377,10 @@ ExtrinsicMappingBasedCalibrator::ExtrinsicMappingBasedCalibrator(
     "mapping_pointcloud", rclcpp::SensorDataQoS().keep_all(),
     std::bind(&CalibrationMapper::mappingPointCloudCallback, mapper_, std::placeholders::_1));
 
-  detected_objects_sub_ =
-    this->create_subscription<autoware_perception_msgs::msg::DetectedObjects>(
-      "detected_objects", rclcpp::SensorDataQoS().keep_all(),
-      std::bind(
-        &ExtrinsicMappingBasedCalibrator::detectedObjectsCallback, this, std::placeholders::_1));
+  detected_objects_sub_ = this->create_subscription<autoware_perception_msgs::msg::DetectedObjects>(
+    "detected_objects", rclcpp::SensorDataQoS().keep_all(),
+    std::bind(
+      &ExtrinsicMappingBasedCalibrator::detectedObjectsCallback, this, std::placeholders::_1));
 
   predicted_objects_sub_ =
     this->create_subscription<autoware_perception_msgs::msg::PredictedObjects>(

--- a/sensor/mapping_based_calibrator/src/mapping_based_calibrator.cpp
+++ b/sensor/mapping_based_calibrator/src/mapping_based_calibrator.cpp
@@ -378,13 +378,13 @@ ExtrinsicMappingBasedCalibrator::ExtrinsicMappingBasedCalibrator(
     std::bind(&CalibrationMapper::mappingPointCloudCallback, mapper_, std::placeholders::_1));
 
   detected_objects_sub_ =
-    this->create_subscription<autoware_auto_perception_msgs::msg::DetectedObjects>(
+    this->create_subscription<autoware_perception_msgs::msg::DetectedObjects>(
       "detected_objects", rclcpp::SensorDataQoS().keep_all(),
       std::bind(
         &ExtrinsicMappingBasedCalibrator::detectedObjectsCallback, this, std::placeholders::_1));
 
   predicted_objects_sub_ =
-    this->create_subscription<autoware_auto_perception_msgs::msg::PredictedObjects>(
+    this->create_subscription<autoware_perception_msgs::msg::PredictedObjects>(
       "predicted_objects", rclcpp::SensorDataQoS().keep_all(),
       std::bind(
         &ExtrinsicMappingBasedCalibrator::predictedObjectsCallback, this, std::placeholders::_1));
@@ -629,7 +629,7 @@ void ExtrinsicMappingBasedCalibrator::requestReceivedCallback(
 }
 
 void ExtrinsicMappingBasedCalibrator::detectedObjectsCallback(
-  const autoware_auto_perception_msgs::msg::DetectedObjects::SharedPtr objects)
+  const autoware_perception_msgs::msg::DetectedObjects::SharedPtr objects)
 {
   // Convert objects into ObjectBB
   ObjectsBB new_objects;
@@ -654,7 +654,7 @@ void ExtrinsicMappingBasedCalibrator::detectedObjectsCallback(
 }
 
 void ExtrinsicMappingBasedCalibrator::predictedObjectsCallback(
-  const autoware_auto_perception_msgs::msg::PredictedObjects::SharedPtr objects)
+  const autoware_perception_msgs::msg::PredictedObjects::SharedPtr objects)
 {
   // Convert objects into ObjectBB
   ObjectsBB new_objects;


### PR DESCRIPTION
## Description

autoware_auto_msgs is eliminated and merged into autoware_msgs. [See this discussion](https://github.com/orgs/autowarefoundation/discussions/3862)

I change autoware_auto_msgs to autoware_msgs in CalibrationTool.

<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

I checked below
- The colcon build finish successfully.
- The GUI starts with the following command
  - ros2 run sensor_calibration_manager sensor_calibration_manager
- Launch mapping based lidar - lidar.

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
