### PR TITLE
fix: init tf tree visualization

### DIFF
--- a/sensor_calibration_manager/sensor_calibration_manager/sensor_calibration_manager.py
+++ b/sensor_calibration_manager/sensor_calibration_manager/sensor_calibration_manager.py
@@ -287,7 +287,7 @@ class SensorCalibrationManager(QMainWindow):
 
     def tf_graph_callback2(self, tfs_dict):
         if (
-            self.calibrator.state != CalibratorState.WAITING_TFS
+            self.calibrator.state != CalibratorState.WAITING_SERVICES
             and self.calibrator.state != CalibratorState.WAITING_TFS
         ):
             return

--- a/sensor_calibration_manager/sensor_calibration_manager/sensor_calibration_manager.py
+++ b/sensor_calibration_manager/sensor_calibration_manager/sensor_calibration_manager.py
@@ -286,7 +286,10 @@ class SensorCalibrationManager(QMainWindow):
         self.tfs_graph_signal.emit(copy.deepcopy(tfs_dict))
 
     def tf_graph_callback2(self, tfs_dict):
-        if self.calibrator.state != CalibratorState.WAITING_TFS:
+        if (
+            self.calibrator.state != CalibratorState.WAITING_TFS
+            and self.calibrator.state != CalibratorState.WAITING_TFS
+        ):
             return
 
         for parent, children_and_tf_dict in tfs_dict.items():


### PR DESCRIPTION
## Description
The calibration launcher in the edge auto project launches the calibration manager and also publishes TFs in the same launch file, which is different from the case when we launch the tools and play the bag (tfs, pointcloud, .etc).

In the edge auto case, the `waiting_service` jumps to the `ready` directly without changing the state to `waiting_tfs`, thus the init tf tree will not be able to visualize in the UI

(Status: waiting service)
1. tf callback continues listening until all of the tf are subscribed. 
(on_check_tf_timer stop)

(Status: waiting service)
2. it starts to check whether the calibrator is available (function: on_service_status_changed)
(Status: ready)

This PR solves this kind of scenario when tf is published before the calibration manager confirm the calibrator service is available.  

<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
