### PR TITLE
feat: update x1 settings for ground plane calibration

### DIFF
--- a/sensor_calibration_manager/launch/x1/ground_plane_calibrator.launch.xml
+++ b/sensor_calibration_manager/launch/x1/ground_plane_calibrator.launch.xml
@@ -13,12 +13,12 @@
   <arg name="filter_estimations" default="true" description="Flag to enable filtering estimations"/>
 
   <arg name="use_crop_box_filter" default="true" description="Use an optional crop box filter to accelerate processing and ignore walls or other planes"/>
-  <arg name="crop_box_min_x" default="-50.0" description="Minimum x value of the crop box filter"/>
-  <arg name="crop_box_min_y" default="-50.0" description="Minimum y value of the crop box filter"/>
-  <arg name="crop_box_min_z" default="-50.0" description="Minimum z value of the crop box filter"/>
-  <arg name="crop_box_max_x" default="50.0" description="Maximum x value of the crop box filter"/>
-  <arg name="crop_box_max_y" default="50.0" description="Maximum y value of the crop box filter"/>
-  <arg name="crop_box_max_z" default="50.0" description="Maximum z value of the crop box filter"/>
+  <arg name="crop_box_min_x" default="-20.0" description="Minimum x value of the crop box filter"/>
+  <arg name="crop_box_min_y" default="-20.0" description="Minimum y value of the crop box filter"/>
+  <arg name="crop_box_min_z" default="-20.0" description="Minimum z value of the crop box filter"/>
+  <arg name="crop_box_max_x" default="20.0" description="Maximum x value of the crop box filter"/>
+  <arg name="crop_box_max_y" default="20.0" description="Maximum y value of the crop box filter"/>
+  <arg name="crop_box_max_z" default="20.0" description="Maximum z value of the crop box filter"/>
   <arg name="use_pca_rough_normal" default="false" description="Whether to use PCA or the initial calibration for normal plane estimation"/>
 
   <arg name="rviz" default="true" description="Launch rviz"/>


### PR DESCRIPTION
## Description
The sensor configuration of X1 is sparse, and using a wide range of pointclouds would result in “Iteration failed”.
Therefore, we narrowed the range of the cropbox filter.
<!-- Write a brief description of this PR. -->

## Related links
[TIER IV INTERNAL LINK](https://star4.slack.com/archives/C07SV18CWQH/p1731020470846159?thread_ts=1730936963.173269&cid=C07SV18CWQH)
<!-- Write the links related to this PR. -->

## Tests performed
Tested on real vehicle.
output by sensor_calibration_manager
``` yaml
base_link:
  sensor_kit_base_link:
    x: 0.632681
    y: -0.014855
    z: 2.160467
    roll: 0.007074
    pitch: 0.013207
    yaw: -0.000000

```
<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
