### PR TITLE
fix(mapping_based_calibrator): typo in the lidar-lidar calibrator

### DIFF
--- a/calibrators/mapping_based_calibrator/src/calibration_mapper.cpp
+++ b/calibrators/mapping_based_calibrator/src/calibration_mapper.cpp
@@ -461,7 +461,7 @@ void CalibrationMapper::checkKeyframeLost(Frame::Ptr keyframe)
 
   if (
     std::abs(translation_angle_diff) > parameters_->lost_frame_max_angle_diff_ ||
-    std::abs(translation_angle_diff) > parameters_->lost_frame_max_angle_diff_) {
+    std::abs(rotation_angle_diff) > parameters_->lost_frame_max_angle_diff_) {
     keyframe->lost_ = true;
 
     RCLCPP_WARN(


### PR DESCRIPTION
## Description
As pointed in https://github.com/tier4/CalibrationTools/issues/209, the `checkKeyframeLost` was wrongly computed due to a typo that ignored one of the conditions. This PR addresses that issue.

<!-- Write a brief description of this PR. -->

## Related links
Issue: https://github.com/tier4/CalibrationTools/issues/209
<!-- Write the links related to this PR. -->

## Tests performed
None
<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
