### PR TITLE
feat(tag_based_pnp_calibrator): choose between sqpnp and iterative automatically

### DIFF
--- a/calibrators/tag_based_pnp_calibrator/CMakeLists.txt
+++ b/calibrators/tag_based_pnp_calibrator/CMakeLists.txt
@@ -18,6 +18,7 @@ ament_auto_add_executable(tag_based_pnp_calibrator
   src/tag_based_pnp_calibrator.cpp
   src/tag_calibrator_visualizer.cpp
   src/main.cpp
+  src/math.cpp
 )
 
 target_link_libraries(tag_based_pnp_calibrator

--- a/calibrators/tag_based_pnp_calibrator/include/tag_based_pnp_calibrator/calibration_estimator.hpp
+++ b/calibrators/tag_based_pnp_calibrator/include/tag_based_pnp_calibrator/calibration_estimator.hpp
@@ -93,7 +93,9 @@ public:
   double getNewHypothesisDistance() const;
   double getCalibrationCoveragePercentage() const;
   int getCurrentCalibrationPairsNumber() const;
-  double getCrossValidationReprojectionError() const;
+  double computeCrossValidationReprojectionError(
+    const std::vector<cv::Point3d> & object_points, const std::vector<cv::Point2d> & image_points);
+  std::tuple<bool, double> getCrossValidationReprojectionError();
   int getConvergencePairNumber() const;
 
 private:
@@ -104,13 +106,11 @@ private:
     bool use_estimated);
 
   std::tuple<bool, cv::Matx31d, cv::Matx33d> calibrate(
-    const std::vector<cv::Point3d> & object_points, const std::vector<cv::Point2d> & image_points);
+    const std::vector<cv::Point3d> & object_points,
+    const std::vector<cv::Point2d> & image_points) const;
 
   tf2::Transform toTf2(
     const cv::Matx31d & translation_vector, const cv::Matx33d & rotation_matrix) const;
-
-  void computeCrossValidationReprojectionError(
-    const std::vector<cv::Point3d> & object_points, const std::vector<cv::Point2d> & image_points);
 
   // Parameters
 
@@ -160,7 +160,6 @@ private:
   std::vector<std::shared_ptr<tier4_tag_utils::ApriltagHypothesis>> converged_apriltag_hypotheses_;
 
   // Output
-  double crossvalidation_reprojection_error_;
   bool valid_;
   cv::Matx33d hypothesis_rotation_matrix_, observation_rotation_matrix_;
   cv::Matx31d hypothesis_translation_vector_, observation_translation_vector_;

--- a/calibrators/tag_based_pnp_calibrator/include/tag_based_pnp_calibrator/math.hpp
+++ b/calibrators/tag_based_pnp_calibrator/include/tag_based_pnp_calibrator/math.hpp
@@ -1,0 +1,36 @@
+// Copyright 2024 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TAG_BASED_PNP_CALIBRATOR__MATH_HPP_
+#define TAG_BASED_PNP_CALIBRATOR__MATH_HPP_
+
+#include <opencv2/core.hpp>
+#include <opencv2/opencv.hpp>
+
+#include <vector>
+
+double getReprojectionError(
+  const std::vector<cv::Point2d> & points1, const std::vector<cv::Point2d> & points2);
+
+double getReprojectionError(
+  const std::vector<cv::Point3d> & object_points, const std::vector<cv::Point2d> & image_points,
+  const cv::Matx31d & translation_vector, const cv::Matx33d & rotation_matrix,
+  const cv::Matx33d & camera_matrix, const cv::Mat_<double> & distortion_coeffs);
+
+double getReprojectionError(
+  const std::vector<cv::Point3d> & object_points, const std::vector<cv::Point2d> & image_points,
+  const cv::Matx31d & translation_vector, const cv::Matx31d & rotation_vector,
+  const cv::Matx33d & camera_matrix, const cv::Mat_<double> & distortion_coeffs);
+
+#endif  // TAG_BASED_PNP_CALIBRATOR__MATH_HPP_

--- a/calibrators/tag_based_pnp_calibrator/include/tag_based_pnp_calibrator/tag_calibrator_visualizer.hpp
+++ b/calibrators/tag_based_pnp_calibrator/include/tag_based_pnp_calibrator/tag_calibrator_visualizer.hpp
@@ -58,7 +58,7 @@ public:
   void setBaseLidarTransform(
     const cv::Matx31d & translation_vector, const cv::Matx33d & rotation_matrix);
 
-  void drawCalibrationStatus(const CalibrationEstimator & estimation, rclcpp::Time & stamp);
+  void drawCalibrationStatus(CalibrationEstimator & estimation, rclcpp::Time & stamp);
 
   void drawAprilTagDetections(
     const apriltag_msgs::msg::AprilTagDetectionArray::SharedPtr & apriltag_detection_array);
@@ -86,7 +86,7 @@ private:
   void drawCalibrationZone(
     rclcpp::Time & stamp, visualization_msgs::msg::MarkerArray & marker_array);
   void drawCalibrationStatusText(
-    const CalibrationEstimator & estimator, rclcpp::Time & stamp,
+    CalibrationEstimator & estimator, rclcpp::Time & stamp,
     visualization_msgs::msg::MarkerArray & marker_array);
 
   std::vector<cv::Point3d> get3dpoints(apriltag_msgs::msg::AprilTagDetection & detection);

--- a/calibrators/tag_based_pnp_calibrator/src/calibration_estimator.cpp
+++ b/calibrators/tag_based_pnp_calibrator/src/calibration_estimator.cpp
@@ -18,6 +18,7 @@
 #include <opencv2/imgproc.hpp>
 #include <tag_based_pnp_calibrator/brute_force_matcher.hpp>
 #include <tag_based_pnp_calibrator/calibration_estimator.hpp>
+#include <tag_based_pnp_calibrator/math.hpp>
 #include <tf2_eigen/tf2_eigen.hpp>
 
 #include <pcl/point_types.h>
@@ -46,7 +47,6 @@ CalibrationEstimator::CalibrationEstimator()
   apriltag_new_hypothesis_translation_(10.0),
   apriltag_process_noise_translation_(0.5),
   apriltag_measurement_noise_translation_(2.0),
-  crossvalidation_reprojection_error_(std::numeric_limits<double>::infinity()),
   valid_(false)
 {
 }
@@ -463,13 +463,12 @@ bool CalibrationEstimator::calibrate()
     hypothesis_rotation_matrix_ = hypothesis_rotation_matrix;
   }
 
-  computeCrossValidationReprojectionError(estimated_object_points, estimated_image_points);
-
   return status;
 }
 
 std::tuple<bool, cv::Matx31d, cv::Matx33d> CalibrationEstimator::calibrate(
-  const std::vector<cv::Point3d> & object_points, const std::vector<cv::Point2d> & image_points)
+  const std::vector<cv::Point3d> & object_points,
+  const std::vector<cv::Point2d> & image_points) const
 {
   cv::Matx31d translation_vector;
   cv::Matx33d rotation_matrix;
@@ -483,19 +482,36 @@ std::tuple<bool, cv::Matx31d, cv::Matx33d> CalibrationEstimator::calibrate(
   auto camera_intrinsics = pinhole_camera_model_.intrinsicMatrix();
   auto distortion_coeffs = pinhole_camera_model_.distortionCoeffs();
 
-  cv::Mat rvec, tvec;
+  cv::Matx31d sq_tvec, iterative_tvec;
+  cv::Matx31d sq_rvec, iterative_rvec;
 
-  bool success = cv::solvePnP(
-    object_points, image_points, camera_intrinsics, distortion_coeffs, rvec, tvec, false,
+  bool sq_success = cv::solvePnP(
+    object_points, image_points, camera_intrinsics, distortion_coeffs, sq_rvec, sq_tvec, false,
     cv::SOLVEPNP_SQPNP);
 
-  if (!success) {
+  bool iterative_success = cv::solvePnP(
+    object_points, image_points, camera_intrinsics, distortion_coeffs, iterative_rvec,
+    iterative_tvec, false, cv::SOLVEPNP_ITERATIVE);
+
+  if (!sq_success && !iterative_success) {
     RCLCPP_ERROR(rclcpp::get_logger("calibration_estimator"), "PNP failed");
     return std::tuple<bool, cv::Matx31d, cv::Matx33d>(false, translation_vector, rotation_matrix);
   }
 
-  translation_vector = tvec;
-  cv::Rodrigues(rvec, rotation_matrix);
+  double sq_error = getReprojectionError(
+    object_points, image_points, sq_tvec, sq_rvec, camera_intrinsics, distortion_coeffs);
+
+  double iterative_error = getReprojectionError(
+    object_points, image_points, iterative_tvec, iterative_rvec, camera_intrinsics,
+    distortion_coeffs);
+
+  if (sq_error < iterative_error) {
+    translation_vector = sq_tvec;
+    cv::Rodrigues(sq_rvec, rotation_matrix);
+  } else {
+    translation_vector = iterative_tvec;
+    cv::Rodrigues(iterative_rvec, rotation_matrix);
+  }
 
   return std::tuple<bool, cv::Matx31d, cv::Matx33d>(true, translation_vector, rotation_matrix);
 }
@@ -515,7 +531,7 @@ tf2::Transform CalibrationEstimator::toTf2(
   return tf2::Transform(tf2_rotation_matrix, tf2_trans);
 }
 
-void CalibrationEstimator::computeCrossValidationReprojectionError(
+double CalibrationEstimator::computeCrossValidationReprojectionError(
   const std::vector<cv::Point3d> & object_points, const std::vector<cv::Point2d> & image_points)
 {
   // Iterate a number of times
@@ -531,8 +547,11 @@ void CalibrationEstimator::computeCrossValidationReprojectionError(
   std::size_t training_size = crossvalidation_training_ratio_ * object_points.size();
 
   if (static_cast<int>(training_size) < min_pnp_pairs_) {
-    return;
+    return std::numeric_limits<double>::infinity();
   }
+
+  const auto & camera_matrix = pinhole_camera_model_.intrinsicMatrix();
+  const auto & distortion_coeffs = pinhole_camera_model_.distortionCoeffs();
 
   double error = 0.0;
 
@@ -557,25 +576,35 @@ void CalibrationEstimator::computeCrossValidationReprojectionError(
     [[maybe_unused]] auto [status, iter_translation_vector, iter_rotation_matrix] =
       calibrate(training_object_points, training_image_points);
 
+    double reprojection_error = getReprojectionError(
+      test_object_points, test_image_points, iter_translation_vector, iter_rotation_matrix,
+      camera_matrix, distortion_coeffs);
+
     cv::Matx31d iter_rvec;
     cv::Rodrigues(iter_rotation_matrix, iter_rvec);
 
-    cv::projectPoints(
-      test_object_points, iter_rvec, iter_translation_vector,
-      pinhole_camera_model_.intrinsicMatrix(), pinhole_camera_model_.distortionCoeffs(),
-      eval_projected_points);
-
-    double reprojection_error = 0.0;
-    for (std::size_t i = 0; i < test_image_points.size(); i++) {
-      double dist = cv::norm(test_image_points[i] - eval_projected_points[i]);
-      reprojection_error += dist;
-    }
-
-    reprojection_error /= test_image_points.size();
     error += reprojection_error;
   }
 
-  crossvalidation_reprojection_error_ = error / trials;
+  return error / trials;
+}
+
+std::tuple<bool, double> CalibrationEstimator::getCrossValidationReprojectionError()
+{
+  // Return the current or filtered pose depending on which fits their set better
+  auto [current_object_points, current_image_points] = getCalibrationPoints(false);
+  auto [filtered_object_points, filtered_image_points] = getCalibrationPoints(true);
+
+  double current_crossval_reprojection_error =
+    computeCrossValidationReprojectionError(current_object_points, current_image_points);
+  double filtered_crossval_reprojection_error =
+    computeCrossValidationReprojectionError(filtered_object_points, filtered_image_points);
+
+  if (current_crossval_reprojection_error < filtered_crossval_reprojection_error) {
+    return std::tuple<bool, double>(false, current_crossval_reprojection_error);
+  } else {
+    return std::tuple<bool, double>(true, filtered_crossval_reprojection_error);
+  }
 }
 
 bool CalibrationEstimator::converged() const
@@ -764,11 +793,6 @@ double CalibrationEstimator::getCalibrationCoveragePercentage() const
 int CalibrationEstimator::getCurrentCalibrationPairsNumber() const
 {
   return converged_lidartag_hypotheses_.size();
-}
-
-double CalibrationEstimator::getCrossValidationReprojectionError() const
-{
-  return crossvalidation_reprojection_error_;
 }
 
 int CalibrationEstimator::getConvergencePairNumber() const { return convergence_min_pairs_; }

--- a/calibrators/tag_based_pnp_calibrator/src/math.cpp
+++ b/calibrators/tag_based_pnp_calibrator/src/math.cpp
@@ -1,0 +1,61 @@
+// Copyright 2024 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <opencv2/core.hpp>
+#include <opencv2/opencv.hpp>
+#include <tag_based_pnp_calibrator/math.hpp>
+
+#include <vector>
+
+double getReprojectionError(
+  const std::vector<cv::Point2d> & points1, const std::vector<cv::Point2d> & points2)
+{
+  double error = 0.0;
+
+  for (std::size_t i = 0; i < points1.size(); i++) {
+    error += cv::norm(points1[i] - points2[i]);
+  }
+
+  return error / points1.size();
+}
+
+double getReprojectionError(
+  const std::vector<cv::Point3d> & object_points, const std::vector<cv::Point2d> & image_points,
+  const cv::Matx31d & translation_vector, const cv::Matx33d & rotation_matrix,
+  const cv::Matx33d & camera_matrix, const cv::Mat_<double> & distortion_coeffs)
+{
+  std::vector<cv::Point2d> projected_points;
+
+  cv::Matx31d rvec;
+  cv::Rodrigues(rotation_matrix, rvec);
+
+  cv::projectPoints(
+    object_points, rvec, translation_vector, camera_matrix, distortion_coeffs, projected_points);
+
+  return getReprojectionError(image_points, projected_points);
+}
+
+double getReprojectionError(
+  const std::vector<cv::Point3d> & object_points, const std::vector<cv::Point2d> & image_points,
+  const cv::Matx31d & translation_vector, const cv::Matx31d & rotation_vector,
+  const cv::Matx33d & camera_matrix, const cv::Mat_<double> & distortion_coeffs)
+{
+  std::vector<cv::Point2d> projected_points;
+
+  cv::projectPoints(
+    object_points, rotation_vector, translation_vector, camera_matrix, distortion_coeffs,
+    projected_points);
+
+  return getReprojectionError(image_points, projected_points);
+}

--- a/calibrators/tag_based_pnp_calibrator/src/tag_based_pnp_calibrator.cpp
+++ b/calibrators/tag_based_pnp_calibrator/src/tag_based_pnp_calibrator.cpp
@@ -16,6 +16,7 @@
 #include <opencv2/core.hpp>
 #include <opencv2/core/eigen.hpp>
 #include <rclcpp/time.hpp>
+#include <tag_based_pnp_calibrator/math.hpp>
 #include <tag_based_pnp_calibrator/tag_based_pnp_calibrator.hpp>
 #include <tf2_eigen/tf2_eigen.hpp>
 
@@ -299,16 +300,28 @@ void ExtrinsicTagBasedPNPCalibrator::requestReceivedCallback(
     }
   }
 
-  tf2::Transform optical_axis_to_lidar_tf2 = estimator_.getFilteredPoseAsTF();
+  auto [use_filtered, crossval_reprojection_error] =
+    estimator_.getCrossValidationReprojectionError();
+
+  tf2::Transform optical_axis_to_lidar_tf2;
+
+  if (use_filtered) {
+    optical_axis_to_lidar_tf2 = estimator_.getFilteredPoseAsTF();
+  } else {
+    optical_axis_to_lidar_tf2 = estimator_.getCurrentPoseAsTF();
+  }
+
+  std::stringstream message_ss;
+  message_ss << "Calibrated using " << estimator_.getCurrentCalibrationPairsNumber() << " pairs "
+             << "(using " << (use_filtered ? "filtered" : "current") << " observations)";
 
   geometry_msgs::msg::Transform transform_msg;
   transform_msg = tf2::toMsg(optical_axis_to_lidar_tf2);
 
   tier4_calibration_msgs::msg::CalibrationResult result;
   result.success = true;
-  result.score = estimator_.getCrossValidationReprojectionError();
-  result.message.data =
-    "Calibrated using " + std::to_string(estimator_.getCurrentCalibrationPairsNumber()) + " pairs";
+  result.score = crossval_reprojection_error;
+  result.message.data = message_ss.str();
   result.transform_stamped.transform = tf2::toMsg(optical_axis_to_lidar_tf2);
   result.transform_stamped.header.frame_id = optical_frame_;
   result.transform_stamped.child_frame_id = lidar_frame_;
@@ -395,54 +408,44 @@ void ExtrinsicTagBasedPNPCalibrator::automaticCalibrationTimerCallback()
     cv::eigen2cv(initial_translation_eigen, initial_trans_vector);
 
     // Calculate the reprojection errors
-    cv::Matx31d initial_rvec, current_rvec, filtered_rvec;
-
-    cv::Rodrigues(initial_rotation_matrix, initial_rvec);
+    cv::Matx31d current_rvec;
     cv::Rodrigues(current_rotation_matrix, current_rvec);
-    cv::Rodrigues(filtered_rotation_matrix, filtered_rvec);
 
     visualizer_->setCameraLidarTransform(filtered_trans_vector, filtered_rotation_matrix);
-
-    std::vector<cv::Point2d> current_projected_points, initial_projected_points,
-      filtered_projected_points;
 
     auto camera_intrinsics = pinhole_camera_model_.intrinsicMatrix();
     auto distortion_coeffs = pinhole_camera_model_.distortionCoeffs();
 
     // Obtain the calibration points
-    auto [object_points, image_points] = estimator_.getCalibrationPoints(false);
+    auto [current_object_points, current_image_points] = estimator_.getCalibrationPoints(false);
+    auto [filtered_object_points, filtered_image_points] = estimator_.getCalibrationPoints(true);
 
-    if (object_points.size() == 0 || image_points.size() == 0) {
+    if (current_object_points.size() == 0 || current_image_points.size() == 0) {
       RCLCPP_ERROR(this->get_logger(), "Could not get the calibration points");
       return;
     }
 
-    cv::projectPoints(
-      object_points, initial_rvec, initial_trans_vector, camera_intrinsics, distortion_coeffs,
-      initial_projected_points);
+    double initial_reprojection_error = 0.f;
+    double current_reprojection_error = getReprojectionError(
+      current_object_points, current_image_points, current_trans_vector, current_rotation_matrix,
+      camera_intrinsics, distortion_coeffs);
+    double filtered_reprojection_error = getReprojectionError(
+      filtered_object_points, filtered_image_points, filtered_trans_vector,
+      filtered_rotation_matrix, camera_intrinsics, distortion_coeffs);
 
-    cv::projectPoints(
-      object_points, current_rvec, current_trans_vector, camera_intrinsics, distortion_coeffs,
-      current_projected_points);
+    if (current_reprojection_error < filtered_reprojection_error) {
+      initial_reprojection_error = getReprojectionError(
+        current_object_points, current_image_points, initial_trans_vector, initial_rotation_matrix,
+        camera_intrinsics, distortion_coeffs);
 
-    cv::projectPoints(
-      object_points, filtered_rvec, filtered_trans_vector, camera_intrinsics, distortion_coeffs,
-      filtered_projected_points);
+      publishCalibrationPoints(current_object_points, current_image_points);
+    } else {
+      initial_reprojection_error = getReprojectionError(
+        filtered_object_points, filtered_image_points, initial_trans_vector,
+        initial_rotation_matrix, camera_intrinsics, distortion_coeffs);
 
-    auto reprojection_error = [](auto & points1, auto & points2) -> double {
-      double error = 0.0;
-
-      for (std::size_t i = 0; i < points1.size(); i++) {
-        error += cv::norm(points1[i] - points2[i]);
-      }
-
-      return error / points1.size();
-    };
-
-    double initial_reprojection_error = reprojection_error(image_points, initial_projected_points);
-    double current_reprojection_error = reprojection_error(image_points, current_projected_points);
-    double filtered_reprojection_error =
-      reprojection_error(image_points, filtered_projected_points);
+      publishCalibrationPoints(filtered_object_points, filtered_image_points);
+    }
 
     RCLCPP_INFO(
       this->get_logger(),
@@ -454,9 +457,6 @@ void ExtrinsicTagBasedPNPCalibrator::automaticCalibrationTimerCallback()
       this->get_logger(), "\tCurrent reprojection error=%.2f", current_reprojection_error);
     RCLCPP_INFO(
       this->get_logger(), "\tFiltered reprojection error=%.2f", filtered_reprojection_error);
-
-    // Publish calibration points
-    publishCalibrationPoints(object_points, image_points);
   }
 
   visualizer_->drawCalibrationStatus(estimator_, latest_timestamp_);

--- a/calibrators/tag_based_pnp_calibrator/src/tag_calibrator_visualizer.cpp
+++ b/calibrators/tag_based_pnp_calibrator/src/tag_calibrator_visualizer.cpp
@@ -79,7 +79,7 @@ void TagCalibratorVisualizer::setBaseLidarTransform(
 }
 
 void TagCalibratorVisualizer::drawCalibrationStatus(
-  const CalibrationEstimator & estimator, rclcpp::Time & stamp)
+  CalibrationEstimator & estimator, rclcpp::Time & stamp)
 {
   visualization_msgs::msg::MarkerArray marker_array;
   circle_diameter_ = estimator.getNewHypothesisDistance();
@@ -371,7 +371,7 @@ void TagCalibratorVisualizer::drawCalibrationZone(
 }
 
 void TagCalibratorVisualizer::drawCalibrationStatusText(
-  const CalibrationEstimator & estimator, rclcpp::Time & stamp,
+  CalibrationEstimator & estimator, rclcpp::Time & stamp,
   visualization_msgs::msg::MarkerArray & marker_array)
 {
   if (!valid_base_lidar_transform_) {
@@ -403,11 +403,15 @@ void TagCalibratorVisualizer::drawCalibrationStatusText(
   text_marker.ns = "calibration_status";
   text_marker.scale.z = 0.3;
 
+  auto [use_filtered, crossval_reprojection_error] =
+    estimator.getCrossValidationReprojectionError();
+  std::string best_crossval_set = use_filtered ? "filtered" : "current";
+
   text_marker.text =
     "pairs=" + std::to_string(estimator.getCurrentCalibrationPairsNumber()) +
     "\ncoverage=" + to_string_with_precision(estimator.getCalibrationCoveragePercentage()) +
     "\ncrossvalidation_reprojection_error=" +
-    to_string_with_precision(estimator.getCrossValidationReprojectionError());
+    to_string_with_precision(crossval_reprojection_error) + " (" + best_crossval_set + ")";
 
   text_marker.pose.position.x = base_lidar_translation_vector(0);
   text_marker.pose.position.y = base_lidar_translation_vector(1);


### PR DESCRIPTION
<!-- Write a brief description of this PR. -->

In the past we used sqpnp as the pnp algorithm because it behaved better in our used cases.
However, for recent cases, the default iterative algorithm has shown better results, so in this PR I made it so that the one with the least reprojection error solution is chosen.

Additionally in noisy environment (wind), the filtering may be compromised so I added an option to chose automatically between the filtered hypotheses and the last observations depending on which set gives a better fit.

## Related links

<!-- Write the links related to this PR. -->
[TIER IV INTERNAL LINK](https://tier4.atlassian.net/wiki/spaces/~69616678/pages/3479045366/Intrinsic+extrinsic+calibration+for+X2+Gen2+Akebono)

## Tests performed

Calibrated camera-lidar for our Gen2 internal project
<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
