### PR TITLE
feat(ceres_intrinsic_camera_calibrator): soften coeffs residuals

### DIFF
--- a/calibrators/intrinsic_camera_calibrator/ceres_intrinsic_camera_calibrator/include/ceres_intrinsic_camera_calibrator/distortion_coefficients_residual.hpp
+++ b/calibrators/intrinsic_camera_calibrator/ceres_intrinsic_camera_calibrator/include/ceres_intrinsic_camera_calibrator/distortion_coefficients_residual.hpp
@@ -21,7 +21,6 @@
 struct DistortionCoefficientsResidual
 {
   static constexpr int RESIDUAL_DIM = 8;
-  static constexpr double LOSS_THRESHOLD = 5.0;
 
   DistortionCoefficientsResidual(
     int radial_distortion_coeffs, bool use_tangential_distortion, int rational_distortion_coeffs)
@@ -77,8 +76,7 @@ struct DistortionCoefficientsResidual
   template <typename T>
   T getResidual(const T & value) const
   {
-    return ceres::abs(value) > LOSS_THRESHOLD ? ceres::pow(ceres::abs(value) - LOSS_THRESHOLD, 2)
-                                              : T(0.0);
+    return ceres::log(ceres::abs(value) + T(1.0));
   }
 
   /*!

--- a/calibrators/intrinsic_camera_calibrator/ceres_intrinsic_camera_calibrator/src/ceres_camera_intrinsics_optimizer.cpp
+++ b/calibrators/intrinsic_camera_calibrator/ceres_intrinsic_camera_calibrator/src/ceres_camera_intrinsics_optimizer.cpp
@@ -360,13 +360,15 @@ void CeresCameraIntrinsicsOptimizer::solve()
     }
   }
 
-  problem.AddResidualBlock(
-    DistortionCoefficientsResidual::createResidual(
-      radial_distortion_coefficients_, use_tangential_distortion_,
-      rational_distortion_coefficients_),
-    new ceres::ScaledLoss(
-      nullptr, regularization_weight_ * object_points_.size(), ceres::TAKE_OWNERSHIP),  // L2
-    intrinsics_placeholder_.data());
+  if (regularization_weight_ > 0.0) {
+    problem.AddResidualBlock(
+      DistortionCoefficientsResidual::createResidual(
+        radial_distortion_coefficients_, use_tangential_distortion_,
+        rational_distortion_coefficients_),
+      new ceres::ScaledLoss(
+        nullptr, regularization_weight_ * object_points_.size(), ceres::TAKE_OWNERSHIP),  // L2
+      intrinsics_placeholder_.data());
+  }
 
   double initial_cost = 0.0;
   std::vector<double> residuals;

--- a/calibrators/intrinsic_camera_calibrator/ceres_intrinsic_camera_calibrator/src/ceres_camera_intrinsics_optimizer.cpp
+++ b/calibrators/intrinsic_camera_calibrator/ceres_intrinsic_camera_calibrator/src/ceres_camera_intrinsics_optimizer.cpp
@@ -376,7 +376,7 @@ void CeresCameraIntrinsicsOptimizer::solve()
   problem.Evaluate(eval_opt, &initial_cost, &residuals, nullptr, nullptr);
 
   if (verbose_) {
-    std::cout << "Initial cost: " << initial_cost;
+    std::cout << "Initial cost: " << initial_cost << std::endl;
   }
 
   ceres::Solver::Options options;
@@ -392,6 +392,6 @@ void CeresCameraIntrinsicsOptimizer::solve()
   ceres::Solve(options, &problem, &summary);
 
   if (verbose_) {
-    std::cout << "Report: " << summary.FullReport();
+    std::cout << "Report: " << std::endl << summary.FullReport() << std::endl;
   }
 }

--- a/calibrators/intrinsic_camera_calibrator/intrinsic_camera_calibrator/intrinsic_camera_calibrator/camera_calibrator.py
+++ b/calibrators/intrinsic_camera_calibrator/intrinsic_camera_calibrator/intrinsic_camera_calibrator/camera_calibrator.py
@@ -811,6 +811,8 @@ class CameraIntrinsicsCalibratorUI(QMainWindow):
         self.calibration_evaluation_inlier_rms_label.setText(
             f"\trms error (inliers): {evaluation_inlier_rms_error:.3f}"  # noqa E231
         )
+        logging.info(f"Camera matrix:\n{calibrated_model.k}")
+        logging.info(f"Distortion coefficients:\n{calibrated_model.d}")
 
         self.calibrator_type_combobox.setEnabled(True)
         self.calibration_parameters_button.setEnabled(True)


### PR DESCRIPTION
## Description

Currently, one of residual block encourages solver to find solution as close to 0.0 as it is possible. This PR relaxes this rule by ignoring residuals lower than defined threshold.

<!-- Write a brief description of this PR. -->

## Related links

* [TIER IV internal link](https://star4.slack.com/archives/C057JDFS5M2/p1737330047776869)

<!-- Write the links related to this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
