### PR TITLE
fix(mapping_based_lidar_lidar_calibrator): result dictionary typo

### DIFF
--- a/sensor_calibration_manager/sensor_calibration_manager/calibrators/rdv/mapping_based_lidar_lidar_calibrator.py
+++ b/sensor_calibration_manager/sensor_calibration_manager/calibrators/rdv/mapping_based_lidar_lidar_calibrator.py
@@ -81,14 +81,13 @@ class MappingBasedLidarLidarCalibrator(CalibratorBase):
         ]
 
         result = {
-            self.sensor_kit_frame: {
+            self.sensor_kit_frame:
                 dict(
                     zip(
                         self.calibration_base_lidar_frames,
                         sensor_kit_to_calibration_lidar_transforms,
                     )
                 )
-            }
         }
 
         return result

--- a/sensor_calibration_manager/sensor_calibration_manager/calibrators/rdv/mapping_based_lidar_lidar_calibrator.py
+++ b/sensor_calibration_manager/sensor_calibration_manager/calibrators/rdv/mapping_based_lidar_lidar_calibrator.py
@@ -81,13 +81,12 @@ class MappingBasedLidarLidarCalibrator(CalibratorBase):
         ]
 
         result = {
-            self.sensor_kit_frame:
-                dict(
-                    zip(
-                        self.calibration_base_lidar_frames,
-                        sensor_kit_to_calibration_lidar_transforms,
-                    )
+            self.sensor_kit_frame: dict(
+                zip(
+                    self.calibration_base_lidar_frames,
+                    sensor_kit_to_calibration_lidar_transforms,
                 )
+            )
         }
 
         return result

--- a/sensor_calibration_manager/sensor_calibration_manager/calibrators/xx1/mapping_based_lidar_lidar_calibrator.py
+++ b/sensor_calibration_manager/sensor_calibration_manager/calibrators/xx1/mapping_based_lidar_lidar_calibrator.py
@@ -77,13 +77,12 @@ class MappingBasedLidarLidarCalibrator(CalibratorBase):
         ]
 
         result = {
-            self.sensor_kit_frame:
-                dict(
-                    zip(
-                        self.calibration_base_lidar_frames,
-                        sensor_kit_to_calibration_lidar_transforms,
-                    )
+            self.sensor_kit_frame: dict(
+                zip(
+                    self.calibration_base_lidar_frames,
+                    sensor_kit_to_calibration_lidar_transforms,
                 )
+            )
         }
 
         return result

--- a/sensor_calibration_manager/sensor_calibration_manager/calibrators/xx1/mapping_based_lidar_lidar_calibrator.py
+++ b/sensor_calibration_manager/sensor_calibration_manager/calibrators/xx1/mapping_based_lidar_lidar_calibrator.py
@@ -77,14 +77,13 @@ class MappingBasedLidarLidarCalibrator(CalibratorBase):
         ]
 
         result = {
-            self.sensor_kit_frame: {
+            self.sensor_kit_frame:
                 dict(
                     zip(
                         self.calibration_base_lidar_frames,
                         sensor_kit_to_calibration_lidar_transforms,
                     )
                 )
-            }
         }
 
         return result


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
This PR fix mapping based lidar lidar calibration bug when you call ```ros2 service call /stop_mapping std_srvs/srv/Empty``` which is disgussed #239 

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
Under: 
* Ubuntu 22.04
* Ros2 Humble
* Cyclone DDS

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
