### PR TITLE
fix: move image decompressor node and update launch arguments for com…

### DIFF
--- a/calibrators/tag_based_pnp_calibrator/launch/apriltag_16h5.launch.py
+++ b/calibrators/tag_based_pnp_calibrator/launch/apriltag_16h5.launch.py
@@ -21,8 +21,22 @@ def generate_launch_description():
         launch_arguments.append(DeclareLaunchArgument(name, default_value=default_value))
 
     add_launch_arg("image_topic", "/camera/image")
+    add_launch_arg("image_compressed_topic", "/camera/image/compressed")
     add_launch_arg("camera_info_topic", "/camera/camera_info")
     add_launch_arg("apriltag_detections_topic", "apriltag/detection_array")
+
+    decompressor_node = ComposableNode(
+        package="autoware_image_transport_decompressor", # The package containing the component
+        plugin="autoware::image_preprocessor::ImageTransportDecompressor", # The registered plugin name
+        name="decompressor",                             # Node name within the container
+        remappings=[
+            ("decompressor/input/compressed_image", LaunchConfiguration("image_compressed_topic")),
+            ("decompressor/output/raw_image", LaunchConfiguration("image_topic")),
+        ],
+        parameters=[
+            {"encoding": "default"}
+        ]
+    )
 
     composable_node = ComposableNode(
         name="apriltag",
@@ -42,7 +56,7 @@ def generate_launch_description():
         namespace="apriltag",
         package="rclcpp_components",
         executable="component_container",
-        composable_node_descriptions=[composable_node],
+        composable_node_descriptions=[decompressor_node, composable_node],
         output="screen",
     )
 

--- a/calibrators/tag_based_pnp_calibrator/launch/apriltag_16h5.launch.py
+++ b/calibrators/tag_based_pnp_calibrator/launch/apriltag_16h5.launch.py
@@ -26,16 +26,14 @@ def generate_launch_description():
     add_launch_arg("apriltag_detections_topic", "apriltag/detection_array")
 
     decompressor_node = ComposableNode(
-        package="autoware_image_transport_decompressor", # The package containing the component
-        plugin="autoware::image_preprocessor::ImageTransportDecompressor", # The registered plugin name
-        name="decompressor",                             # Node name within the container
+        package="autoware_image_transport_decompressor",  # The package containing the component
+        plugin="autoware::image_preprocessor::ImageTransportDecompressor",  # The registered plugin name
+        name="decompressor",  # Node name within the container
         remappings=[
             ("decompressor/input/compressed_image", LaunchConfiguration("image_compressed_topic")),
             ("decompressor/output/raw_image", LaunchConfiguration("image_topic")),
         ],
-        parameters=[
-            {"encoding": "default"}
-        ]
+        parameters=[{"encoding": "default"}],
     )
 
     composable_node = ComposableNode(

--- a/calibrators/tag_based_pnp_calibrator/launch/calibrator.launch.xml
+++ b/calibrators/tag_based_pnp_calibrator/launch/calibrator.launch.xml
@@ -1,5 +1,6 @@
 <launch>
   <arg name="image_topic" description="Raw image topic (currently we do not support rectified images)"/>
+  <arg name="image_compressed_topic" description="Compressed image topic"/>
   <arg name="camera_info_topic"/>
   <arg name="pointcloud_topic"/>
   <arg name="base_frame" default="base_link"/>
@@ -37,6 +38,7 @@
   <!-- apriltag detector -->
   <include file="$(find-pkg-share tag_based_pnp_calibrator)/launch/apriltag_16h5.launch.py">
     <arg name="image_topic" value="$(var image_topic)"/>
+    <arg name="image_compressed_topic" value="$(var image_compressed_topic)"/>
     <arg name="camera_info_topic" value="$(var camera_info_topic)"/>
   </include>
 

--- a/sensor_calibration_manager/launch/drs/tag_based_pnp_calibrator.launch.xml
+++ b/sensor_calibration_manager/launch/drs/tag_based_pnp_calibrator.launch.xml
@@ -46,17 +46,9 @@
   <let name="use_rectified_image" value="false"/>
 
   <group>
-    <!-- image decompressor -->
-    <node pkg="autoware_image_transport_decompressor" exec="image_transport_decompressor_node" name="decompressor" output="screen">
-      <remap from="decompressor/input/compressed_image" to="$(var image_compressed_topic)"/>
-      op
-      <remap from="decompressor/output/raw_image" to="$(var image_decompressed_topic)"/>
-
-      <param name="encoding" value="default"/>
-    </node>
-
     <!-- tag based calibrator -->
     <include file="$(find-pkg-share tag_based_pnp_calibrator)/launch/calibrator.launch.xml">
+      <arg name="image_compressed_topic" value="$(var image_compressed_topic)"/>
       <arg name="image_topic" value="$(var image_decompressed_topic)"/>
       <arg name="camera_info_topic" value="$(var camera_info_topic)"/>
       <arg name="pointcloud_topic" value="$(var pointcloud_topic)"/>


### PR DESCRIPTION
## Description
Fixed calibration failures with high-resolution images by migrating the decompression node to component containers, which reduced excessive latency in topic communication.

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
