### PR TITLE
fix: intrinsic_camera_calibrator can use with dot_board

### DIFF
--- a/calibrators/intrinsic_camera_calibrator/intrinsic_camera_calibrator/config/c2_intrinsics_calibrator.yaml
+++ b/calibrators/intrinsic_camera_calibrator/intrinsic_camera_calibrator/config/c2_intrinsics_calibrator.yaml
@@ -1,5 +1,5 @@
 # yamllint disable-line rule:truthy
-board_type: chess_board
+board_type: dot_board
 board_parameters:
   cols: 8
   rows: 6

--- a/calibrators/intrinsic_camera_calibrator/intrinsic_camera_calibrator/config/ceres_intrinsics_calibrator.yaml
+++ b/calibrators/intrinsic_camera_calibrator/intrinsic_camera_calibrator/config/ceres_intrinsics_calibrator.yaml
@@ -1,5 +1,5 @@
 # yamllint disable-line rule:truthy
-board_type: chess_board
+board_type: dot_board
 board_parameters:
   cols: 8
   rows: 6

--- a/calibrators/intrinsic_camera_calibrator/intrinsic_camera_calibrator/config/general_intrinsics_calibrator.yaml
+++ b/calibrators/intrinsic_camera_calibrator/intrinsic_camera_calibrator/config/general_intrinsics_calibrator.yaml
@@ -1,5 +1,5 @@
 # yamllint disable-line rule:truthy
-board_type: chess_board
+board_type: dot_board
 board_parameters:
   cols: 8
   rows: 6

--- a/calibrators/intrinsic_camera_calibrator/intrinsic_camera_calibrator/intrinsic_camera_calibrator/camera_calibrator.py
+++ b/calibrators/intrinsic_camera_calibrator/intrinsic_camera_calibrator/intrinsic_camera_calibrator/camera_calibrator.py
@@ -1296,17 +1296,6 @@ class CameraIntrinsicsCalibratorUI(QMainWindow):
 
     def process_new_data(self):
         """Attempt to request the detector to process an image. However, if it there is an image being processed, does not enqueue them indefinitely. Instead, only leave the last one."""
-        # if was not found the pattern skip some frames
-        if (
-            self.data_collector.skip_frames_when_not_detection.value
-            and self.skip_next_img > 1
-            and self.data_source_type != DataSourceEnum.FILES
-        ):
-            self.detector.restart_lost_frames_counter()  # to force next frame detection
-            self.skip_next_img -= 1
-            self.consumed_data_signal.emit()
-            return
-
         if self.data_source_type == DataSourceEnum.FILES:
             self.detector.restart_lost_frames_counter()  # to force next frame detection
 


### PR DESCRIPTION
`intrinsic_camera_calibrator`にてカメラの内パラをdot_boardで取得できないバグを修正しました。

- UI上でdot_boardを選択してもchess_boardになるバグを修正
- markerが検出されない場合にすぐに固まるバグを修正