### PR TITLE
feat: explicitly use ot128 to avoid future problem

### DIFF
--- a/calibrators/tag_based_pnp_calibrator/launch/calibrator.launch.xml
+++ b/calibrators/tag_based_pnp_calibrator/launch/calibrator.launch.xml
@@ -24,6 +24,9 @@
     <choice value="seyond_robin_w"/>
     <choice value="velodyne_vlp16"/>
     <choice value="velodyne_vls128"/>
+    <choice value="ot128"/>
+    <choice value="ot128_clipped"/>
+    <choice value="qt128"/>
   </arg>
 
   <arg name="calibration_service_name" default="extrinsic_calibration"/>

--- a/calibrators/tag_based_sfm_calibrator/launch/lidartag_detector.launch.xml
+++ b/calibrators/tag_based_sfm_calibrator/launch/lidartag_detector.launch.xml
@@ -19,6 +19,9 @@
     <choice value="seyond_robin_w"/>
     <choice value="velodyne_vlp16"/>
     <choice value="velodyne_vls128"/>
+    <choice value="ot128"/>
+    <choice value="ot128_clipped"/>
+    <choice value="qt128"/>
   </arg>
 
   <group>

--- a/sensor_calibration_manager/launch/default_project/tag_based_pnp_calibrator.launch.xml
+++ b/sensor_calibration_manager/launch/default_project/tag_based_pnp_calibrator.launch.xml
@@ -23,6 +23,9 @@
     <choice value="seyond_robin_w"/>
     <choice value="velodyne_vlp16"/>
     <choice value="velodyne_vls128"/>
+    <choice value="ot128"/>
+    <choice value="ot128_clipped"/>
+    <choice value="qt128"/>
   </arg>
 
   <let name="rviz_profile" value=""/>

--- a/sensor_calibration_manager/launch/xx1_gen2/tag_based_pnp_calibrator.launch.xml
+++ b/sensor_calibration_manager/launch/xx1_gen2/tag_based_pnp_calibrator.launch.xml
@@ -26,7 +26,7 @@
 
   <let name="camera_frame" value="$(var camera_name)/camera_link"/>
   <let name="rviz_profile" value="$(find-pkg-share tag_based_pnp_calibrator)/rviz/default_profile.rviz"/>
-  <let name="lidar_model" value="velodyne_vls128"/>
+  <let name="lidar_model" value="ot128"/>
   <!--Note: The OT128 should work with the same profile as the VLS128 -->
   <let name="lidar_frame" value="hesai_top"/>
   <let name="use_rectified_image" value="false"/>

--- a/sensor_calibration_manager/launch/xx1_gen2/tag_based_sfm_base_lidar_calibrator.launch.xml
+++ b/sensor_calibration_manager/launch/xx1_gen2/tag_based_sfm_base_lidar_calibrator.launch.xml
@@ -12,7 +12,7 @@
   <let name="main_calibration_sensor_frame" value="hesai_top"/>
 
   <!-- Lidar configuration -->
-  <let name="calibration_lidar_model" value="velodyne_vls128"/>
+  <let name="calibration_lidar_model" value="ot128"/>
 
   <!-- Topic configuration -->
   <let name="calibration_lidar_topic" value="/sensing/lidar/top/pointcloud_raw_ex"/>


### PR DESCRIPTION
## Description

<img width="2053" height="321" alt="image" src="https://github.com/user-attachments/assets/85f40b4a-99eb-4f51-84ea-37a9a5ef7a18" />

1. The parameter file in the LiDARTag repository has only a small difference for OT128/velodyne_vls128.
2. But to avoid future problems, I would suggest synchronize the parameter sets in LiDAR Tag to the this system to avoid future problems

## Related links

LiDAR Tag: https://github.com/tier4/LiDARTag/pull/22
<!-- Write the links related to this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
