### PR TITLE
fix: use the most basic pointcloud topics for XX1 Gen2

### DIFF
--- a/sensor_calibration_manager/launch/xx1_gen2/mapping_based_lidar_lidar_calibrator.launch.xml
+++ b/sensor_calibration_manager/launch/xx1_gen2/mapping_based_lidar_lidar_calibrator.launch.xml
@@ -27,11 +27,11 @@
   <let
     name="calibration_pointcloud_topics"
     value="[
-    /sensing/lidar/side_left/rectified/pointcloud_ex,
-    /sensing/lidar/side_right/rectified/pointcloud_ex,
-    /sensing/lidar/front_left/rectified/pointcloud_ex,
-    /sensing/lidar/front_right/rectified/pointcloud_ex,
-    /sensing/lidar/rear/rectified/pointcloud_ex]"
+    /sensing/lidar/side_left/pointcloud_raw_ex,
+    /sensing/lidar/side_right/pointcloud_raw_ex,
+    /sensing/lidar/front_left/pointcloud_raw_ex,
+    /sensing/lidar/front_right/pointcloud_raw_ex,
+    /sensing/lidar/rear/pointcloud_raw_ex]"
   />
 
   <!-- mapping based calibrator -->


### PR DESCRIPTION
## Description

Because of updates in XX1 Gen2 to use [Cuda preprocessor](https://github.com/tier4/aip_launcher/blob/tier4/universe/aip_common_sensor_launch/launch/nebula_node_container.launch.py), topic names are changed. 

We update to use the most primitive point clouds from the nebula nodes so that at least nodes can correctly finish for basic tests.

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
