### PR TITLE
feat(sensor_calibration_manager): save preferences for launcher_configuration_view

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ Finally, to save the results, press the `save calibration` button.
 
 #### Preferences
 
-The last user selection of `project` and `calibrator` is automatically saved in `~/.config/tier4/sensor_calibration_manager.conf`, which is helpful in case of repeating the same calibration for different sensor configurations.
+The last user selections of `project`, `calibrator`, and the launcher configurations for each project/calibrator are automatically saved in `~/.config/tier4/sensor_calibration_manager.conf`, which is helpful in case of repeating the same calibration for different sensor configurations.
 
 To clear this preference, simply remove this file.
 

--- a/sensor_calibration_manager/sensor_calibration_manager/views/launcher_configuration_view.py
+++ b/sensor_calibration_manager/sensor_calibration_manager/views/launcher_configuration_view.py
@@ -18,6 +18,7 @@ from functools import reduce
 import logging
 from typing import Dict
 
+from PySide2.QtCore import QSettings
 from PySide2.QtCore import Signal
 from PySide2.QtWidgets import QComboBox
 from PySide2.QtWidgets import QGridLayout
@@ -33,6 +34,8 @@ from launch.actions.declare_launch_argument import DeclareLaunchArgument
 from launch.frontend import Parser
 from launch.launch_description import LaunchDescription
 
+PREFERENCES_GROUP_PREFIX = "launcher_configuration_view"
+
 
 class LauncherConfigurationView(QWidget):
     """A simple widget to visualize and edit a ParameterizedClass's parameters."""
@@ -42,6 +45,9 @@ class LauncherConfigurationView(QWidget):
 
     def __init__(self, project_name, calibrator_name):
         super().__init__()
+
+        self.settings = QSettings()
+        self.preferences_group = f"{PREFERENCES_GROUP_PREFIX}/{project_name}/{calibrator_name}"
 
         self.setWindowTitle("Launcher configuration")
 
@@ -94,13 +100,13 @@ class LauncherConfigurationView(QWidget):
                 )  # KL: not sure if should the first or last default value
 
                 self.optional_arguments_dict[e.name] = {
-                    "value": default_value,
+                    "default": default_value,
                     "description": description,
                     "choices": e.choices,
                 }
             else:
                 self.required_arguments_dict[e.name] = {
-                    "value": "",
+                    "default": "",
                     "description": description,
                     "choices": e.choices,
                 }
@@ -113,19 +119,26 @@ class LauncherConfigurationView(QWidget):
             name_label = QLabel(argument_name)
             name_label.setMaximumWidth(400)
 
-            default_value = argument_data["value"].replace(" ", "")
+            initial_value = self.settings.value(
+                f"{self.preferences_group}/{argument_name}",
+                argument_data["default"].replace(" ", ""),  # fallback
+                type=str,
+            )
 
             if argument_data["choices"] is None or len(argument_data["choices"]) == 0:
-                self.arguments_widgets_dict[argument_name] = QLineEdit(default_value)
-                self.arguments_widgets_dict[argument_name].textChanged.connect(
-                    self.check_argument_status
-                )
+                line_edit = QLineEdit(initial_value)
+
+                line_edit.textChanged.connect(self.check_argument_status)
+                self.arguments_widgets_dict[argument_name] = line_edit
 
             else:
                 combo_box = QComboBox()
-
                 for choice in argument_data["choices"]:
                     combo_box.addItem(choice)
+
+                initial_index = combo_box.findText(initial_value)
+                if initial_index != -1:
+                    combo_box.setCurrentIndex(initial_index)
 
                 combo_box.currentTextChanged.connect(self.check_argument_status)
                 self.arguments_widgets_dict[argument_name] = combo_box
@@ -152,17 +165,26 @@ class LauncherConfigurationView(QWidget):
             name_label = QLabel(argument_name)
             name_label.setMaximumWidth(400)
 
+            initial_value = self.settings.value(
+                f"{self.preferences_group}/{argument_name}",
+                argument_data["default"],  # fallback
+                type=str,
+            )
+
             if argument_data["choices"] is None or len(argument_data["choices"]) == 0:
-                self.arguments_widgets_dict[argument_name] = QLineEdit(argument_data["value"])
-                self.arguments_widgets_dict[argument_name].textChanged.connect(
-                    self.check_argument_status
-                )
+                line_edit = QLineEdit(initial_value)
+
+                line_edit.textChanged.connect(self.check_argument_status)
+                self.arguments_widgets_dict[argument_name] = line_edit
 
             else:
                 combo_box = QComboBox()
-
                 for choice in argument_data["choices"]:
                     combo_box.addItem(choice)
+
+                initial_index = combo_box.findText(initial_value)
+                if initial_index != -1:
+                    combo_box.setCurrentIndex(initial_index)
 
                 combo_box.currentTextChanged.connect(self.check_argument_status)
                 self.arguments_widgets_dict[argument_name] = combo_box
@@ -228,6 +250,9 @@ class LauncherConfigurationView(QWidget):
             return len(arg) >= 2 and arg[0] == "[" and arg[-1] == "]"
 
         for key, value in args_dict.items():
+            # save preferences
+            self.settings.setValue(f"{self.preferences_group}/{key}", value)
+
             if is_list(value):
                 args_dict[key]: Dict[str, str] = [
                     item.strip() for item in value.strip("[]").split(",")


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Save the most recent launcher configurations (per project / calibration) into `~/.config/tier4/sensor_calibration_manager.conf` using `QSettings`. Configurations are only saved when the user hit 'Launch'.

## Related links

<!-- Write the links related to this PR. -->

#262 

## Tests performed

<!-- Describe how you have tested this PR. -->

[Screencast from 2025年10月20日 14時00分43秒.webm](https://github.com/user-attachments/assets/a0b7c48e-778f-4606-a6a3-41560ded8f57)

If you launch a project/calibrator with certain configuration, then the arguments are saved and loaded when you launch the same project/calibrator combination. If the launcher is closed via interruption, then the arguments are not saved. Calibrators with same name but from different projects do not share the configuration preference.

The configuration file after applying this PR and saving some preferences will look like below:

```
[calibrator_selector_view]
calibrator=tag_based_pnp_calibrator
project=xx1_15

[launcher_configuration_view]
xx1\tag_based_sfm_base_lidar_calibrator\left_wheel_tag_id=22
xx1\tag_based_sfm_base_lidar_calibrator\publish_tfs=true
xx1\tag_based_sfm_base_lidar_calibrator\right_wheel_tag_id=26
xx1\tag_based_sfm_base_lidar_calibrator\rviz=true
xx1\tag_based_sfm_base_lidar_calibrator\waypoint_tag_ids="[0,1,2,3,4,5]"
xx1_gen2\tag_based_pnp_calibrator\calibration_pairs=8
xx1_gen2\tag_based_pnp_calibrator\calibration_pairs_min_distance=1.2
xx1_gen2\tag_based_pnp_calibrator\camera_name=camera3
xx1_gen2\tag_based_pnp_calibrator\view_only_ui=false
```

(Note that the preferences are saved if you haven't modified from the default value. Maybe we can patch this to save only non-defaults, but that is of low priority.)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
