### PR TITLE
fix: handle not-implemented error in dot board detector

### DIFF
--- a/calibrators/intrinsic_camera_calibrator/intrinsic_camera_calibrator/intrinsic_camera_calibrator/board_detectors/dotboard_detector.py
+++ b/calibrators/intrinsic_camera_calibrator/intrinsic_camera_calibrator/intrinsic_camera_calibrator/board_detectors/dotboard_detector.py
@@ -183,3 +183,12 @@ class DotBoardDetector(BoardDetector):
         )
 
         self.detection_results_signal.emit(img, detection, stamp)
+
+    def restart_lost_frames_counter(self):
+        """
+        Reset the counter for lost frames.
+
+        This is an empty implementation as the DotBoardDetector does not track lost frames.
+        The method exists to satisfy the interface requirements of the parent BoardDetector class.
+        """
+        pass


### PR DESCRIPTION
## Description

Because the dotboard detector did not have the restart_lost_frame_counter trigger function, it caused quite a lot of problems.

After this fix, the dot board detector will run fine.

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
