### PR TITLE
feat: fix the board type when it is manually selected

### DIFF
--- a/calibrators/intrinsic_camera_calibrator/intrinsic_camera_calibrator/intrinsic_camera_calibrator/views/initialization_view.py
+++ b/calibrators/intrinsic_camera_calibrator/intrinsic_camera_calibrator/intrinsic_camera_calibrator/views/initialization_view.py
@@ -64,6 +64,10 @@ class InitializationView(QWidget):
             board_type: make_board_parameters(board_type, cfg=self.cfg["board_parameters"])
             for board_type in BoardEnum
         }
+        # Flag to track if user manually selected a board type
+        self.user_selected_board_type = False
+        # Flag to prevent the initial setup from triggering the manual selection
+        self.initializing = True
 
         # Get the package share directory
         package_share_dir = get_package_share_directory("intrinsic_camera_calibrator")
@@ -118,7 +122,15 @@ class InitializationView(QWidget):
                     with open(config_file_path, "r") as stream:
                         cfg = yaml.safe_load(stream)
                         self.cfg = defaultdict(dict, cfg)
-                        self.update_board_type()
+                        # Only update board type if user hasn't manually selected one
+                        if not self.user_selected_board_type:
+                            self.update_board_type()
+                            # Keep the non-user selection state
+                            self.user_selected_board_type = False
+                        else:
+                            # Still update parameters but keep the user's board type selection
+                            logging.info("NOT update board type: User manually selected board type")
+                            self.update_board_parameters()
                         logging.info("Successfully opened parameters file")
                 except Exception as e:
                     logging.error(f"Could not load the parameters from the YAML file ({e})")
@@ -141,6 +153,17 @@ class InitializationView(QWidget):
         for board_type in BoardEnum:
             self.board_type_combobox.addItem(board_type.value["display"], board_type)
 
+        # Connect board type combobox to track manual selection
+        def on_board_type_changed(index):
+            # Only set the flag if not during initialization
+            if not self.initializing:
+                self.user_selected_board_type = True
+                # Update board parameters for the newly selected board type
+                self.update_board_parameters()
+
+        self.board_type_combobox.currentIndexChanged.connect(on_board_type_changed)
+
+        # Set up the board type before connecting the signal
         self.update_board_type()
 
         def board_parameters_on_closed():
@@ -206,9 +229,12 @@ class InitializationView(QWidget):
         self.layout.addWidget(self.initial_intrinsics_group)
         self.layout.addWidget(self.start_button)
 
+        # Initialization is complete
+        self.initializing = False
         self.show()
 
     def update_board_type(self):
+        """Update both the board type selection and parameters."""
         if self.cfg["board_type"] != "":
             self.board_type_combobox.setCurrentIndex(
                 BoardEnum.from_name(self.cfg["board_type"]).get_id()
@@ -216,6 +242,10 @@ class InitializationView(QWidget):
         else:
             self.board_type_combobox.setCurrentIndex(0)
 
+        self.update_board_parameters()
+
+    def update_board_parameters(self):
+        """Update only the board parameters without changing the selected board type."""
         self.board_parameters_dict = {
             board_type: make_board_parameters(board_type, cfg=self.cfg["board_parameters"])
             for board_type in BoardEnum

--- a/calibrators/intrinsic_camera_calibrator/intrinsic_camera_calibrator/intrinsic_camera_calibrator/views/initialization_view.py
+++ b/calibrators/intrinsic_camera_calibrator/intrinsic_camera_calibrator/intrinsic_camera_calibrator/views/initialization_view.py
@@ -51,6 +51,35 @@ class InitializationView(QWidget):
     closed = Signal()
 
     def __init__(self, calibrator: "CameraIntrinsicsCalibratorUI", cfg):  # noqa F821
+        """Initialize the calibrator configuration widget.
+
+        This widget allows users to configure data sources, board types, and operation modes
+        for camera calibration.
+
+        State diagram for board type selection behavior:
+        ```
+        +----------------+     initialization     +----------------------+
+        |                |     complete           |                      |
+        | Initial Setup  +----------------------->| Auto Update Board    |
+        |                |                        | Type                 |
+        +----------------+                        |                      |
+                                                  +----------+-----------+
+                                                             |
+                                                             | User selects
+                                                             | board type from
+                                                             | combobox
+                                                             v
+                                                  +----------+-----------+
+                                                  |                      |
+                                                  | Manual Board Type    |
+                                                  | Selection            |
+                                                  |                      |
+                                                  +----------------------+
+
+        - Auto Update Board Type: Calls update_board_type() + update_board_parameters()
+        - Manual Board Type: Calls update_board_parameters() only, board type remains fixed
+        ```
+        """
         super().__init__()
 
         self.setWindowTitle("Initial configuration")

--- a/calibrators/intrinsic_camera_calibrator/intrinsic_camera_calibrator/intrinsic_camera_calibrator/views/initialization_view.py
+++ b/calibrators/intrinsic_camera_calibrator/intrinsic_camera_calibrator/intrinsic_camera_calibrator/views/initialization_view.py
@@ -183,14 +183,14 @@ class InitializationView(QWidget):
             self.board_type_combobox.addItem(board_type.value["display"], board_type)
 
         # Connect board type combobox to track manual selection
-        def on_board_type_changed(index):
+        def on_board_type_changed(board_type_str):
             # Only set the flag if not during initialization
             if not self.initializing:
                 self.user_selected_board_type = True
                 # Update board parameters for the newly selected board type
                 self.update_board_parameters()
 
-        self.board_type_combobox.currentIndexChanged.connect(on_board_type_changed)
+        self.board_type_combobox.currentTextChanged.connect(on_board_type_changed)
 
         # Set up the board type before connecting the signal
         self.update_board_type()


### PR DESCRIPTION
## Description

### Background

Originally, changing the camera calibrator will automatically change the board type according to the config file.

### Update

This PR proposes:

- When we **only** play with the config files, the board type will change according to the config files.
- When we **manually changed** the board type once, the board type will **NOT** change according to the config files during the session.
    - Idea: In the calibration field, when we manually choose the board, it usually means we already know which board will be used in the real calibration field. Then selecting the calibrator configuration only means we are working on changing the calibration parameters.


```mermaid
stateDiagram-v2
    direction LR
    
    [*] --> InitialSetup
    
    state "Initial Setup" as InitialSetup
    state "Auto Update Board Type" as AutoUpdateBoardType
    state "Manual Board Type" as ManualBoardType
    
    InitialSetup --> AutoUpdateBoardType : Initialization Complete<br/>(initializing = false)
    
    AutoUpdateBoardType --> ManualBoardType : User selects board type<br/>from combobox
    ManualBoardType --> AutoUpdateBoardType : Relaunch
    
    note right of AutoUpdateBoardType
        Calls update_board_type()
        + update_board_parameters()
    end note
    
    note right of ManualBoardType
        Calls update_board_parameters()
        Board type remains fixed
    end note
```

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
