### PR TITLE
fix(pointcloud rendering): cut off overdistorted region on pointcloud rendering

### DIFF
--- a/calibrators/interactive_camera_lidar_calibrator/interactive_camera_lidar_calibrator/image_view.py
+++ b/calibrators/interactive_camera_lidar_calibrator/interactive_camera_lidar_calibrator/image_view.py
@@ -351,10 +351,9 @@ class ImageView(QGraphicsItem, QObject):
             self.data_ui.d = np.copy(d).reshape((-1,))
 
             # Calculate critical r^2, such that the distorted radial coordinate
-            # r * (1 + k1*r^2 + k2*r^4 + k3*r^6) starts decreasing.
+            # r*(1+k1*r^2+k2*r^4+k3*r^6)/(1+k4*r^2+k5*r^4+k6*r^6) starts decreasing.
             # Note that if p1, p2 (tangential distortion) are non-zero,
-            # or there is denominator in the distortion model,
-            # then the 'folding boundary' cannot be calculated analytically,
+            # then the 'folding boundary' cannot be determined by r^2 alone,
             # and this calculation is only an approximation.
             self.data_ui.critical_r2 = np.inf
 

--- a/calibrators/interactive_camera_lidar_calibrator/interactive_camera_lidar_calibrator/image_view.py
+++ b/calibrators/interactive_camera_lidar_calibrator/interactive_camera_lidar_calibrator/image_view.py
@@ -96,6 +96,8 @@ class RenderingData:
         self.k = None
         self.d = None
 
+        self.critical_r2 = np.inf
+
 
 class CustomQGraphicsView(QGraphicsView):
     def __init__(self, parent=None):
@@ -348,6 +350,45 @@ class ImageView(QGraphicsItem, QObject):
             self.data_ui.k = np.copy(k).reshape((3, 3))
             self.data_ui.d = np.copy(d).reshape((-1,))
 
+            # Calculate critical r^2, such that the distorted radial coordinate
+            # r * (1 + k1*r^2 + k2*r^4 + k3*r^6) starts decreasing.
+            # Note that if p1, p2 (tangential distortion) are non-zero,
+            # or there is denominator in the distortion model,
+            # then the 'folding boundary' cannot be calculated analytically,
+            # and this calculation is only an approximation.
+            self.data_ui.critical_r2 = np.inf
+
+            d = self.data_ui.d.flatten()
+            if d.shape[0] >= 2:
+                k1 = d[0]
+                k2 = d[1]
+                k3 = 0
+                if d.shape[0] >= 5:
+                    k3 = d[4]
+                k4 = 0
+                k5 = 0
+                k6 = 0
+                if d.shape[0] >= 8:
+                    k4 = d[5]
+                    k5 = d[6]
+                    k6 = d[7]
+
+                coeffs = [
+                    k3 * k6,
+                    3 * k3 * k5 - k2 * k6,
+                    5 * k3 * k4 + k2 * k5 - 3 * k1 * k6,
+                    7 * k3 + 3 * k2 * k4 - k1 * k5 - 5 * k6,
+                    5 * k2 + k1 * k4 - 3 * k5,
+                    3 * k1 - k4,
+                    1,
+                ]
+                roots = np.roots(coeffs)
+                real_roots = roots[np.isclose(roots.imag, 0.0)].real
+                positive_roots = real_roots[real_roots > 0.0]
+
+                if len(positive_roots) > 0:
+                    self.data_ui.critical_r2 = np.min(positive_roots)
+
     def set_calibration_points(self, object_points, image_points):
         with self.lock:
             self.data_ui.object_points = object_points
@@ -480,8 +521,12 @@ class ImageView(QGraphicsItem, QObject):
                 np.logical_and(pointcloud_ics[:, 1] >= 0, pointcloud_ics[:, 1] < self.image_height),
             ),
             np.logical_and(
-                pointcloud_ccs[:, 2] >= self.data_renderer.min_rendering_distance,
-                pointcloud_ccs[:, 2] < self.data_renderer.max_rendering_distance,
+                np.logical_and(
+                    pointcloud_ccs[:, 2] >= self.data_renderer.min_rendering_distance,
+                    pointcloud_ccs[:, 2] < self.data_renderer.max_rendering_distance,
+                ),
+                (pointcloud_ccs[:, 0] ** 2 + pointcloud_ccs[:, 1] ** 2)
+                < pointcloud_ccs[:, 2] ** 2 * self.data_renderer.critical_r2,
             ),
         )
 
@@ -528,13 +573,6 @@ class ImageView(QGraphicsItem, QObject):
                 raise NotImplementedError
         except Exception as e:
             logging.error(e)
-
-        line_pen = QPen()
-        line_pen.setWidth(2)
-        line_pen.setBrush(Qt.white)
-
-        painter.setPen(Qt.blue)
-        painter.setBrush(Qt.blue)
 
         draw_marker_f = (
             painter.drawEllipse if self.data_renderer.marker_type == "circles" else painter.drawRect

--- a/common/tier4_calibration_views/tier4_calibration_views/image_view.py
+++ b/common/tier4_calibration_views/tier4_calibration_views/image_view.py
@@ -351,10 +351,9 @@ class ImageView(QGraphicsItem, QObject):
             self.data_ui.d = np.copy(d).reshape((-1,))
 
             # Calculate critical r^2, such that the distorted radial coordinate
-            # r * (1 + k1*r^2 + k2*r^4 + k3*r^6) starts decreasing.
+            # r*(1+k1*r^2+k2*r^4+k3*r^6)/(1+k4*r^2+k5*r^4+k6*r^6) starts decreasing.
             # Note that if p1, p2 (tangential distortion) are non-zero,
-            # or there is denominator in the distortion model,
-            # then the 'folding boundary' cannot be calculated analytically,
+            # then the 'folding boundary' cannot be determined by r^2 alone,
             # and this calculation is only an approximation.
             self.data_ui.critical_r2 = np.inf
 

--- a/common/tier4_calibration_views/tier4_calibration_views/image_view.py
+++ b/common/tier4_calibration_views/tier4_calibration_views/image_view.py
@@ -96,6 +96,8 @@ class RenderingData:
         self.k = None
         self.d = None
 
+        self.critical_r2 = np.inf
+
 
 class CustomQGraphicsView(QGraphicsView):
     def __init__(self, parent=None):
@@ -348,6 +350,45 @@ class ImageView(QGraphicsItem, QObject):
             self.data_ui.k = np.copy(k).reshape((3, 3))
             self.data_ui.d = np.copy(d).reshape((-1,))
 
+            # Calculate critical r^2, such that the distorted radial coordinate
+            # r * (1 + k1*r^2 + k2*r^4 + k3*r^6) starts decreasing.
+            # Note that if p1, p2 (tangential distortion) are non-zero,
+            # or there is denominator in the distortion model,
+            # then the 'folding boundary' cannot be calculated analytically,
+            # and this calculation is only an approximation.
+            self.data_ui.critical_r2 = np.inf
+
+            d = self.data_ui.d.flatten()
+            if d.shape[0] >= 2:
+                k1 = d[0]
+                k2 = d[1]
+                k3 = 0
+                if d.shape[0] >= 5:
+                    k3 = d[4]
+                k4 = 0
+                k5 = 0
+                k6 = 0
+                if d.shape[0] >= 8:
+                    k4 = d[5]
+                    k5 = d[6]
+                    k6 = d[7]
+
+                coeffs = [
+                    k3 * k6,
+                    3 * k3 * k5 - k2 * k6,
+                    5 * k3 * k4 + k2 * k5 - 3 * k1 * k6,
+                    7 * k3 + 3 * k2 * k4 - k1 * k5 - 5 * k6,
+                    5 * k2 + k1 * k4 - 3 * k5,
+                    3 * k1 - k4,
+                    1,
+                ]
+                roots = np.roots(coeffs)
+                real_roots = roots[np.isclose(roots.imag, 0.0)].real
+                positive_roots = real_roots[real_roots > 0.0]
+
+                if len(positive_roots) > 0:
+                    self.data_ui.critical_r2 = np.min(positive_roots)
+
     def set_calibration_points(self, object_points, image_points):
         with self.lock:
             self.data_ui.object_points = object_points
@@ -480,8 +521,12 @@ class ImageView(QGraphicsItem, QObject):
                 np.logical_and(pointcloud_ics[:, 1] >= 0, pointcloud_ics[:, 1] < self.image_height),
             ),
             np.logical_and(
-                pointcloud_ccs[:, 2] >= self.data_renderer.min_rendering_distance,
-                pointcloud_ccs[:, 2] < self.data_renderer.max_rendering_distance,
+                np.logical_and(
+                    pointcloud_ccs[:, 2] >= self.data_renderer.min_rendering_distance,
+                    pointcloud_ccs[:, 2] < self.data_renderer.max_rendering_distance,
+                ),
+                (pointcloud_ccs[:, 0] ** 2 + pointcloud_ccs[:, 1] ** 2)
+                < pointcloud_ccs[:, 2] ** 2 * self.data_renderer.critical_r2,
             ),
         )
 
@@ -528,13 +573,6 @@ class ImageView(QGraphicsItem, QObject):
                 raise NotImplementedError
         except Exception as e:
             logging.error(e)
-
-        line_pen = QPen()
-        line_pen.setWidth(2)
-        line_pen.setBrush(Qt.white)
-
-        painter.setPen(Qt.blue)
-        painter.setBrush(Qt.blue)
 
         draw_marker_f = (
             painter.drawEllipse if self.data_renderer.marker_type == "circles" else painter.drawRect


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

| Before | After |
|--------|--------|
| <img width="1154" height="748" alt="image" src="https://github.com/user-attachments/assets/295341d5-aba7-4456-9142-f0567e4c3d3e" /> | <img width="1154" height="748" alt="image" src="https://github.com/user-attachments/assets/63565bbf-9640-4c52-82af-2fa0bf9f8c92" /> |

Remove front near pointclouds which are not supposed to be displayed in the image view.

The cause is the so-called folding phenomenon: assume an 8-parameter pinhole distortion model, i.e. $D = \[k_1, k_2, p_1, p_2, k_3, k_4, k_5, k_6\]$. The distorted coordinates $(X_{\mathrm{distorted}}, Y_{\mathrm{distorted}})$ before applying the camera intrinsic matrix $K$, are given as:

$$
X_{\mathrm{distorted}} = \frac{1+k_1 r^2 + k_2 r^4 + k_3 r^6}{1+k_4 r^2 + k_5 r^4 + k_6 r^6} x + 2p_1 xy + p_2 (r^2 + 2x^2)
$$

$$
Y_{\mathrm{distorted}} = \frac{1+k_1 r^2 + k_2 r^4 + k_3 r^6}{1+k_4 r^2 + k_5 r^4 + k_6 r^6} y + p_1 (r^2 + 2y^2) + 2p_2 xy
$$

where $x = X/Z, y = Y/Z, r = \sqrt{x^2+y^2}$, and $(X,Y,Z)$ is the camera frame 3d coordinates of a point ( == `pointcloud_ccs`). Furthermore, by applying $K$, the coordinates $(X_{\mathrm{distorted}}, Y_{\mathrm{distorted}})$ are linearly transformed into the actual screen pixel coordinates $(U, V)$ ( == `pointcloud_ics`), but this step does not contribute to the nontrivial properties of the mappings, so its discussions are skipped here.

If no distortions are applied, when we take $(x, y)$ far away from the screen center, then the corresponding $(X_\mathrm{distorted}, Y_\mathrm{distorted})$ is mapped distantly from the center as well. However, since we have nonlinear distortions, distant $(x, y)$ s can be 'folded back' towards to the screen center, e.g. $(1+k_1 r^2 + k_2 r^4 + k_3 r^6)/(1+k_4 r^2 + k_5 r^4 + k_6 r^6) < 0$ cases, hence an irrelevant portion of the pointclouds are rendered on-screen, mapped to the same pixel points with the near-center $(x, y)$ s.

The actual positions of some irrelevant points are depicted as Rviz markers (big green dots) below. Most of them are pointclouds close to the camera plane ($0 < Z << |X|, |Y|$, hence large $|x|, |y|$) and located on the ground.
<img width="368" height="166" alt="image" src="https://github.com/user-attachments/assets/a1a9f84e-2e34-4a47-864a-e17a44c68200" />

A scatter plot of $(x,y)$ from these points:
<img width="640" height="480" alt="Figure_1" src="https://github.com/user-attachments/assets/e3745122-d175-4b71-8b36-c3800194740a" />

For such distant $(x, y)$ the given distortion model is no longer applicable due to the lack of injectiveness, and typically higher order parameters are required to describe the distortion for such overdistorted region. Hence we need to cutoff points at the overdistorted region boundary, which is plausible to define as where the distorted points start folding back to the center.

In general, the boundary is determined by both $r$ and $\theta$ , seen as the polar coordinates of $(x, y)$ which origin is placed at the screen center. To make calculations easy, this PR introduces a $r^2$ - based cutoff. If we ignore the tangential distortion part, i.e. $p_1 = p_2 = 0$, then the cutoff boundary is solely determined by $r$. This $r = r_{\mathrm{critical}}$ can be determined as the least positive real solution which satisfies:

$$
\frac{d}{dr} \left(  \frac{1+k_1 r^2 + k_2 r^4 + k_3 r^6}{1+k_4 r^2 + k_5 r^4 + k_6 r^6} \cdot r \right) = 0
$$

This is a single-variable polynomial equation which can be solved with numpy. For tangentially distorted case however, this cutoff only gives an approximation.

Conclusively, this PR calculates this critical $r_{\mathrm{critical}}$ from the distortion parameters, and then additionally filters out points which violate the $r < r_{\mathrm{critical}}$ i.e. $X^2 + Y^2 < r_{\mathrm{critical}}^2 Z^2$ criteria based on the `pointcloud_ccs` coordinates.

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
