### PR TITLE
feat: add drs_seyond calibration support

### DIFF
--- a/calibrators/tag_based_pnp_calibrator/launch/apriltag_16h5.launch.py
+++ b/calibrators/tag_based_pnp_calibrator/launch/apriltag_16h5.launch.py
@@ -26,16 +26,14 @@ def generate_launch_description():
     add_launch_arg("apriltag_detections_topic", "apriltag/detection_array")
 
     decompressor_node = ComposableNode(
-        package="autoware_image_transport_decompressor", # The package containing the component
-        plugin="autoware::image_preprocessor::ImageTransportDecompressor", # The registered plugin name
-        name="decompressor",                             # Node name within the container
+        package="autoware_image_transport_decompressor",  # The package containing the component
+        plugin="autoware::image_preprocessor::ImageTransportDecompressor",  # The registered plugin name
+        name="decompressor",  # Node name within the container
         remappings=[
             ("decompressor/input/compressed_image", LaunchConfiguration("image_compressed_topic")),
             ("decompressor/output/raw_image", LaunchConfiguration("image_topic")),
         ],
-        parameters=[
-            {"encoding": "default"}
-        ]
+        parameters=[{"encoding": "default"}],
     )
 
     composable_node = ComposableNode(

--- a/docs/tutorials/mapping_based_calibrator.md
+++ b/docs/tutorials/mapping_based_calibrator.md
@@ -147,7 +147,6 @@ The image below displays the vehicle within the pointcloud, allowing for a compa
 ## FAQ
 
 - Why does the calibration fail?
-
   - In most cases, the failure is due to mapping issues. The possible error messages are listed below and should be displayed in the console. For these cases, restart the experiment and drive more stably and slowly.
     - Mapping failed. Angle between keyframes is too high.
     - Mapping failed. Interpolation error is too high.

--- a/docs/tutorials/marker_radar_lidar_calibrator.md
+++ b/docs/tutorials/marker_radar_lidar_calibrator.md
@@ -231,19 +231,16 @@ To evaluate the calibration result, the user can check that the calibrated radar
 ## FAQ
 
 - Why does the reflector detection not appear on `RViz`?
-
   - Make sure the center of the reflector faces toward the radar sensor, and the height of the reflector matches the radar's.
   - Make sure the height of the radar reflector is not larger than the `reflector_max_height` parameter.
   - Make sure the radar reflector is not in the background voxel (visualize the topic mentioned before).
 
 - Why does the calibration error seem high?
-
   - Make sure that there are no outliers in the calibration pairs list.
   - Make sure that the initial calibration is good enough to match the lidar detection and radar detection correctly.
   - Radars like the ARS408 (the one we use in this tutorial) have a resolution of 0.2m. Given that, there is a theoretical limit to how low the calibration error can be. If the radar resolution is low, it will strongly limit the lower bound of the calibration error.
 
 - When can I stop the calibration process?
-
   - It is recommended to stop the calibration when the curve in the cross-validation error has converged.
   - With more matched pairs without outliers, the calibration result should improve if the number of pairs increases.
 

--- a/docs/tutorials/tag_based_pnp_calibrator.md
+++ b/docs/tutorials/tag_based_pnp_calibrator.md
@@ -133,7 +133,6 @@ In the following images we can see how the projection looks using the initial ca
 ## FAQ
 
 - Why does the tool fail to add calibration pairs?
-
   - One possible reason is that the detections are too close to the previously collected data. In this case, the new detections are deemed redundant, and thus not accepted.
   - The timestamps of the lidar and camera are not synchronized. This can be checked with `ros2 topic echo [topic_name] --field header.stamp`. Setting the parameter `use_receive_time` to `True` might help to solve the issue, but is not recommended as a long-term solution.
   - The detections are not stable enough. This can happen due to the following reasons:
@@ -141,17 +140,14 @@ In the following images we can see how the projection looks using the initial ca
     - The tag is physically unstable due to wind, mounting issues, or other external factors. Even if the detector functions correctly, these conditions prevent the detection from converging. If this is the case, please eliminate all unwelcome external factors before attempting calibration. Forcefully calibrating under these conditions can compromise the results.
 
 - Why does the UI not launch?
-
   - Check with `ros2 node list` if the relevant nodes have been launched. It is possible that the provided parameters do not match any of the valid arguments among other standard ROS issues.
   - If the UI crashes (check the console for details), it is probably due to a bad PySide installation, invalid intrinsic parameters, invalid extrinsic parameters, etc.
   - The timestamps of the lidar and camera are not synchronized.
 
 - Why does the reprojection error increase when more data is collected?
-
   - When there are few samples, the model will fit the available data the best it can, even in the presence of noise (over-fitting) or wrong detections. When more data is collected, the error may increase to a certain extent, but that corresponds to the model attempting to fit all the data, this time unable to fit the noise, resulting in a higher error. However, it should reach a more-or-less table peak with about 10-15 pairs (depending on the data collection pattern/sampling).
 
 - Why does the reprojection error seem high?
-
   - The intrinsics may not be accurate, thus limiting the performance of the method.
   - The boards are not appropriate (are bent).
   - The boards moved too much while calibrating.

--- a/sensor_calibration_manager/launch/drs_seyond/mapping_based_lidar_lidar_calibrator.launch.xml
+++ b/sensor_calibration_manager/launch/drs_seyond/mapping_based_lidar_lidar_calibrator.launch.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<launch>
+  <arg name="base_frame" default="drs_base_link"/>
+  <arg name="lost_frame_max_acceleration" default="10.0"/>
+  <arg name="calibration_skip_keyframes" default="7"/>
+  <arg name="mapping_registrator" default="ndt" description="ndt or gicp"/>
+  <arg name="rviz" default="true"/>
+
+  <arg name="mapping_min_range" default="7.0" description="Used to drop self reflections"/>
+  <arg name="mapping_max_range" default="100.0" description="Used to avoid inaccurate points and speed up the process"/>
+  <arg name="calibration_min_distance_between_frames" default="4.0" description="Min separation between calibration clouds to avoid correlation"/>
+  <arg name="dense_pointcloud_num_keyframes" default="30" description="Used to compensate the different field of views"/>
+  <arg name="lidar_calibration_max_frames" default="3" description="Number of pointclouds used for calibration"/>
+
+  <arg name="imu_to_front_x" default="0.3334" description="x translation value from IMU origin to front LiDAR origin"/>
+  <arg name="imu_to_front_y" default="0.0" description="y translation value from IMU origin to front LiDAR origin"/>
+  <arg name="imu_to_front_z" default="0.0702" description="z translation value from IMU origin to front LiDAR origin"/>
+  <arg name="imu_to_front_roll" default="0.000" description="roll rotation value from IMU origin to front LiDAR origin"/>
+  <arg name="imu_to_front_pitch" default="0.000" description="pitch rotation value from IMU origin to front LiDAR origin"/>
+  <arg name="imu_to_front_yaw" default="0.000" description="yaw rotation value from IMU origin to front LiDAR origin"/>
+
+  <let name="calibration_camera_optical_link_frames" value="['']"/>
+
+  <let name="calibration_lidar_frames" value="[
+    lidar_left,
+    lidar_right,
+    lidar_rear]"/>
+
+  <let name="mapping_lidar_frame" value="lidar_front"/>
+  <let name="mapping_pointcloud" value="/sensing/lidar/front/seyond_points"/>
+  <let name="detected_objects" value="/perception/object_recognition/detection/objects"/>
+
+  <let name="calibration_camera_info_topics" value="['']"/>
+
+  <let name="calibration_image_topics" value="[
+    '']"/>
+
+  <let name="calibration_pointcloud_topics" value="[
+    /sensing/lidar/left/seyond_points,
+    /sensing/lidar/right/seyond_points,
+    /sensing/lidar/rear/seyond_points]"/>
+
+  <!-- mapping based calibrator -->
+  <include file="$(find-pkg-share mapping_based_calibrator)/launch/calibrator.launch.xml">
+    <arg name="ns" value=""/>
+    <arg name="calibration_service_name" value="calibrate_lidar_lidar"/>
+
+    <arg name="rviz" value="$(var rviz)"/>
+    <arg name="base_frame" value="$(var base_frame)"/>
+
+    <arg name="calibration_camera_optical_link_frames" value="$(var calibration_camera_optical_link_frames)"/>
+    <arg name="calibration_lidar_frames" value="$(var calibration_lidar_frames)"/>
+    <arg name="mapping_lidar_frame" value="$(var mapping_lidar_frame)"/>
+
+    <arg name="mapping_pointcloud" value="$(var mapping_pointcloud)"/>
+    <arg name="detected_objects" value="$(var detected_objects)"/>
+
+    <arg name="calibration_camera_info_topics" value="$(var calibration_camera_info_topics)"/>
+    <arg name="calibration_image_topics" value="$(var calibration_image_topics)"/>
+    <arg name="calibration_pointcloud_topics" value="$(var calibration_pointcloud_topics)"/>
+
+    <arg name="mapping_registrator" value="$(var mapping_registrator)"/>
+    <arg name="lost_frame_max_acceleration" value="$(var lost_frame_max_acceleration)"/>
+    <arg name="calibration_skip_keyframes" value="$(var calibration_skip_keyframes)"/>
+
+    <arg name="mapping_min_range" value="$(var mapping_min_range)"/>
+    <arg name="mapping_max_range" value="$(var mapping_max_range)"/>
+    <arg name="calibration_min_distance_between_frames" value="$(var calibration_min_distance_between_frames)"/>
+    <arg name="dense_pointcloud_num_keyframes" value="$(var dense_pointcloud_num_keyframes)"/>
+    <arg name="lidar_calibration_max_frames" value="$(var lidar_calibration_max_frames)"/>
+  </include>
+
+  <node
+    pkg="tf2_ros"
+    exec="static_transform_publisher"
+    name="extrinsic_publisher"
+    args="--frame-id base_link --child-frame-id drs_base_link --x 0.6895 --y 0.0 --z 1.6785 --yaw 0.000 --pitch 0.000, --roll 0.000"
+  />
+  <node
+    pkg="tf2_ros"
+    exec="static_transform_publisher"
+    name="extrinsic_publisher"
+    args="--frame-id drs_base_link --child-frame-id lidar_front --x $(var imu_to_front_x) --y $(var imu_to_front_y) --z $(var imu_to_front_z) --yaw $(var imu_to_front_yaw) --pitch $(var imu_to_front_pitch), --roll $(var imu_to_front_roll)"
+  />
+  <node
+    pkg="tf2_ros"
+    exec="static_transform_publisher"
+    name="extrinsic_publisher"
+    args="--frame-id drs_base_link --child-frame-id lidar_left --x 0.000 --y 0.560 --z -0.0532 --yaw 1.5708 --pitch 0.000, --roll 0.000"
+  />
+  <node
+    pkg="tf2_ros"
+    exec="static_transform_publisher"
+    name="extrinsic_publisher"
+    args="--frame-id drs_base_link --child-frame-id lidar_right --x 0.000 --y -0.560 --z -0.0532 --yaw -1.5708 --pitch 0.000, --roll 0.000"
+  />
+  <node
+    pkg="tf2_ros"
+    exec="static_transform_publisher"
+    name="extrinsic_publisher"
+    args="--frame-id drs_base_link --child-frame-id lidar_rear --x -0.2994 --y 0.0 --z 0.0373 --yaw 3.14 --pitch 0.000, --roll 0.000"
+  />
+</launch>

--- a/sensor_calibration_manager/launch/drs_seyond/tag_based_pnp_calibrator.launch.xml
+++ b/sensor_calibration_manager/launch/drs_seyond/tag_based_pnp_calibrator.launch.xml
@@ -29,10 +29,10 @@
   <let name="lidar_frame" value="lidar_left" if="$(eval &quot;'$(var camera_name)' == 'camera6' &quot;)"/>
   <let name="lidar_frame" value="lidar_left" if="$(eval &quot;'$(var camera_name)' == 'camera7' &quot;)"/>
 
-  <let name="pointcloud_topic" value="/sensing/lidar/front/nebula_points" if="$(eval &quot;'$(var lidar_frame)' == 'lidar_front' &quot;)"/>
-  <let name="pointcloud_topic" value="/sensing/lidar/rear/nebula_points" if="$(eval &quot;'$(var lidar_frame)' == 'lidar_rear' &quot;)"/>
-  <let name="pointcloud_topic" value="/sensing/lidar/left/nebula_points" if="$(eval &quot;'$(var lidar_frame)' == 'lidar_left' &quot;)"/>
-  <let name="pointcloud_topic" value="/sensing/lidar/right/nebula_points" if="$(eval &quot;'$(var lidar_frame)' == 'lidar_right' &quot;)"/>
+  <let name="pointcloud_topic" value="/sensing/lidar/front/seyond_points" if="$(eval &quot;'$(var lidar_frame)' == 'lidar_front' &quot;)"/>
+  <let name="pointcloud_topic" value="/sensing/lidar/rear/seyond_points" if="$(eval &quot;'$(var lidar_frame)' == 'lidar_rear' &quot;)"/>
+  <let name="pointcloud_topic" value="/sensing/lidar/left/seyond_points" if="$(eval &quot;'$(var lidar_frame)' == 'lidar_left' &quot;)"/>
+  <let name="pointcloud_topic" value="/sensing/lidar/right/seyond_points" if="$(eval &quot;'$(var lidar_frame)' == 'lidar_right' &quot;)"/>
 
   <let name="camera_frame" value="$(var camera_name)/camera_link"/>
   <let name="camera_optical_frame" value="$(var camera_name)/camera_optical_link"/>

--- a/sensor_calibration_manager/sensor_calibration_manager/calibrators/drs_seyond/__init__.py
+++ b/sensor_calibration_manager/sensor_calibration_manager/calibrators/drs_seyond/__init__.py
@@ -1,0 +1,7 @@
+from .mapping_based_lidar_lidar_calibrator import MappingBasedLidarLidarCalibrator
+from .tag_based_pnp_calibrator import TagBasedPNPCalibrator
+
+__all__ = [
+    "MappingBasedLidarLidarCalibrator",
+    "TagBasedPNPCalibrator",
+]

--- a/sensor_calibration_manager/sensor_calibration_manager/calibrators/drs_seyond/mapping_based_lidar_lidar_calibrator.py
+++ b/sensor_calibration_manager/sensor_calibration_manager/calibrators/drs_seyond/mapping_based_lidar_lidar_calibrator.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+# Copyright 2024 Tier IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Dict
+
+import numpy as np
+
+from sensor_calibration_manager.calibrator_base import CalibratorBase
+from sensor_calibration_manager.calibrator_registry import CalibratorRegistry
+from sensor_calibration_manager.ros_interface import RosInterface
+from sensor_calibration_manager.types import FramePair
+
+
+@CalibratorRegistry.register_calibrator(
+    project_name="drs_seyond", calibrator_name="mapping_based_lidar_lidar_calibrator"
+)
+class MappingBasedLidarLidarCalibrator(CalibratorBase):
+    required_frames = []
+
+    def __init__(self, ros_interface: RosInterface, **kwargs):
+        super().__init__(ros_interface)
+
+        self.base_link = kwargs["base_frame"]
+        self.mapping_lidar_frame = "lidar_front"
+        self.calibration_lidar_frames = ["lidar_left", "lidar_right", "lidar_rear"]
+
+        self.required_frames.extend(
+            [self.base_link, self.mapping_lidar_frame, *self.calibration_lidar_frames]
+        )
+
+        self.add_calibrator(
+            service_name="calibrate_lidar_lidar",
+            expected_calibration_frames=[
+                FramePair(parent=self.mapping_lidar_frame, child=calibration_lidar_frame)
+                for calibration_lidar_frame in self.calibration_lidar_frames
+            ],
+        )
+
+    def post_process(self, calibration_transforms: Dict[str, Dict[str, np.array]]):
+        base_to_mapping_transform = self.get_transform_matrix(
+            self.base_link, self.mapping_lidar_frame
+        )
+
+        base_to_calibration_lidar_transforms = [
+            base_to_mapping_transform
+            @ calibration_transforms[self.mapping_lidar_frame][calibration_lidar_frame]
+            for calibration_lidar_frame in self.calibration_lidar_frames
+        ]
+
+        result = {
+            self.base_link: dict(
+                zip(self.calibration_lidar_frames, base_to_calibration_lidar_transforms)
+            )
+        }
+        result[self.base_link][self.mapping_lidar_frame] = base_to_mapping_transform
+
+        return result

--- a/sensor_calibration_manager/sensor_calibration_manager/calibrators/drs_seyond/tag_based_pnp_calibrator.py
+++ b/sensor_calibration_manager/sensor_calibration_manager/calibrators/drs_seyond/tag_based_pnp_calibrator.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+
+# Copyright 2024 Tier IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Dict
+
+import numpy as np
+
+from sensor_calibration_manager.calibrator_base import CalibratorBase
+from sensor_calibration_manager.calibrator_registry import CalibratorRegistry
+from sensor_calibration_manager.ros_interface import RosInterface
+from sensor_calibration_manager.types import FramePair
+
+
+@CalibratorRegistry.register_calibrator(
+    project_name="drs_seyond", calibrator_name="tag_based_pnp_calibrator"
+)
+class TagBasedPNPCalibrator(CalibratorBase):
+    required_frames = []
+
+    def __init__(self, ros_interface: RosInterface, **kwargs):
+        super().__init__(ros_interface)
+
+        self.camera_name = kwargs["camera_name"]
+        self.lidar_frame = kwargs["lidar_frame"]
+        self.required_frames.append(self.lidar_frame)
+        self.required_frames.append(f"{self.camera_name}/camera_link")
+        self.required_frames.append(f"{self.camera_name}/camera_optical_link")
+
+        self.add_calibrator(
+            service_name="calibrate_camera_lidar",
+            expected_calibration_frames=[
+                FramePair(parent=f"{self.camera_name}/camera_optical_link", child=self.lidar_frame),
+            ],
+        )
+
+    def post_process(self, calibration_transforms: Dict[str, Dict[str, np.array]]):
+        optical_link_to_lidar_transform = calibration_transforms[
+            f"{self.camera_name}/camera_optical_link"
+        ][self.lidar_frame]
+
+        camera_to_optical_link_transform = self.get_transform_matrix(
+            f"{self.camera_name}/camera_link", f"{self.camera_name}/camera_optical_link"
+        )
+
+        lidar_camera_link_transform = np.linalg.inv(
+            camera_to_optical_link_transform @ optical_link_to_lidar_transform
+        )
+
+        result = {
+            self.lidar_frame: {f"{self.camera_name}/camera_link": lidar_camera_link_transform}
+        }
+        return result


### PR DESCRIPTION
## Summary
This PR adds calibration support for the drs_seyond project.

## Changes
- Add drs_seyond project calibration configuration
- Add `tag_based_pnp_calibrator` for drs_seyond
- Add `mapping_based_lidar_lidar_calibrator` for drs_seyond
- Update drs `tag_based_pnp_calibrator`: change `lidar_front` model from `aeva_aeries2` to `seyond_falcon`
- Use `seyond_points` topic for drs_seyond project

## Files Changed
- Modified: `sensor_calibration_manager/launch/drs/tag_based_pnp_calibrator.launch.xml`
- Added: `sensor_calibration_manager/launch/drs_seyond/` directory
- Added: `sensor_calibration_manager/sensor_calibration_manager/calibrators/drs_seyond/` directory