### PR TITLE
refactor: remove default values from IMU to front LiDAR transform parameters

### DIFF
--- a/sensor_calibration_manager/launch/drs/mapping_based_lidar_lidar_calibrator.launch.xml
+++ b/sensor_calibration_manager/launch/drs/mapping_based_lidar_lidar_calibrator.launch.xml
@@ -12,12 +12,12 @@
   <arg name="dense_pointcloud_num_keyframes" default="30" description="Used to compensate the different field of views"/>
   <arg name="lidar_calibration_max_frames" default="3" description="Number of pointclouds used for calibration"/>
 
-  <arg name="imu_to_front_x" default="0.3334" description="x translation value from IMU origin to front LiDAR origin"/>
-  <arg name="imu_to_front_y" default="0.0" description="y translation value from IMU origin to front LiDAR origin"/>
-  <arg name="imu_to_front_z" default="0.0702" description="z translation value from IMU origin to front LiDAR origin"/>
-  <arg name="imu_to_front_roll" default="0.000" description="roll rotation value from IMU origin to front LiDAR origin"/>
-  <arg name="imu_to_front_pitch" default="0.000" description="pitch rotation value from IMU origin to front LiDAR origin"/>
-  <arg name="imu_to_front_yaw" default="0.000" description="yaw rotation value from IMU origin to front LiDAR origin"/>
+  <arg name="imu_to_front_x" description="x translation value from IMU origin to front LiDAR origin"/>
+  <arg name="imu_to_front_y" description="y translation value from IMU origin to front LiDAR origin"/>
+  <arg name="imu_to_front_z" description="z translation value from IMU origin to front LiDAR origin"/>
+  <arg name="imu_to_front_roll" description="roll rotation value from IMU origin to front LiDAR origin"/>
+  <arg name="imu_to_front_pitch" description="pitch rotation value from IMU origin to front LiDAR origin"/>
+  <arg name="imu_to_front_yaw" description="yaw rotation value from IMU origin to front LiDAR origin"/>
 
   <let name="calibration_camera_optical_link_frames" value="['']"/>
 

--- a/sensor_calibration_manager/launch/drs_seyond/mapping_based_lidar_lidar_calibrator.launch.xml
+++ b/sensor_calibration_manager/launch/drs_seyond/mapping_based_lidar_lidar_calibrator.launch.xml
@@ -12,12 +12,12 @@
   <arg name="dense_pointcloud_num_keyframes" default="30" description="Used to compensate the different field of views"/>
   <arg name="lidar_calibration_max_frames" default="3" description="Number of pointclouds used for calibration"/>
 
-  <arg name="imu_to_front_x" default="0.3334" description="x translation value from IMU origin to front LiDAR origin"/>
-  <arg name="imu_to_front_y" default="0.0" description="y translation value from IMU origin to front LiDAR origin"/>
-  <arg name="imu_to_front_z" default="0.0702" description="z translation value from IMU origin to front LiDAR origin"/>
-  <arg name="imu_to_front_roll" default="0.000" description="roll rotation value from IMU origin to front LiDAR origin"/>
-  <arg name="imu_to_front_pitch" default="0.000" description="pitch rotation value from IMU origin to front LiDAR origin"/>
-  <arg name="imu_to_front_yaw" default="0.000" description="yaw rotation value from IMU origin to front LiDAR origin"/>
+  <arg name="imu_to_front_x" description="x translation value from IMU origin to front LiDAR origin"/>
+  <arg name="imu_to_front_y" description="y translation value from IMU origin to front LiDAR origin"/>
+  <arg name="imu_to_front_z" description="z translation value from IMU origin to front LiDAR origin"/>
+  <arg name="imu_to_front_roll" description="roll rotation value from IMU origin to front LiDAR origin"/>
+  <arg name="imu_to_front_pitch" description="pitch rotation value from IMU origin to front LiDAR origin"/>
+  <arg name="imu_to_front_yaw" description="yaw rotation value from IMU origin to front LiDAR origin"/>
 
   <let name="calibration_camera_optical_link_frames" value="['']"/>
 

--- a/sensor_calibration_manager/sensor_calibration_manager/calibrators/__init__.py
+++ b/sensor_calibration_manager/sensor_calibration_manager/calibrators/__init__.py
@@ -1,5 +1,6 @@
 from .default_project import *  # noqa: F401, F403
 from .drs import *  # noqa: F401, F403
+from .drs_seyond import *  # noqa: F401, F403
 from .rdv import *  # noqa: F401, F403
 from .x1 import *  # noqa: F401, F403
 from .x2 import *  # noqa: F401, F403


### PR DESCRIPTION
## Summary
This PR removes default values from IMU to front LiDAR transform parameters and adds drs_seyond module import to ensure proper calibration setup.

## Changes
- Remove default values from `imu_to_front_*` parameters in `drs/mapping_based_lidar_lidar_calibrator.launch.xml`
- Remove default values from `imu_to_front_*` parameters in `drs_seyond/mapping_based_lidar_lidar_calibrator.launch.xml`
- Add `drs_seyond` module import to `calibrators/__init__.py` to enable drs_seyond calibrators registration

## Rationale
These transform parameters should be explicitly provided when launching the calibrator to ensure correct calibration results. Removing defaults prevents accidental use of incorrect values. The drs_seyond module import is necessary to make the drs_seyond calibrators available in the system.