### PR TITLE
feat: add drs_seyond module import to calibrators __init__

### DIFF
--- a/sensor_calibration_manager/sensor_calibration_manager/calibrators/__init__.py
+++ b/sensor_calibration_manager/sensor_calibration_manager/calibrators/__init__.py
@@ -1,5 +1,6 @@
 from .default_project import *  # noqa: F401, F403
 from .drs import *  # noqa: F401, F403
+from .drs_seyond import *  # noqa: F401, F403
 from .rdv import *  # noqa: F401, F403
 from .x1 import *  # noqa: F401, F403
 from .x2 import *  # noqa: F401, F403


### PR DESCRIPTION
## Summary
This PR adds the drs_seyond module import to the calibrators __init__.py file to enable drs_seyond calibrators registration.

## Changes
- Add `drs_seyond` module import to `sensor_calibration_manager/sensor_calibration_manager/calibrators/__init__.py`

## Rationale
The drs_seyond module import is necessary to make the drs_seyond calibrators (tag_based_pnp_calibrator and mapping_based_lidar_lidar_calibrator) available and registered in the calibration system. Without this import, the calibrators defined in the drs_seyond module would not be discoverable by the calibration manager.